### PR TITLE
Add auto merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,36 @@
+name: Auto merge pull requests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto approve
+        uses: hmarr/auto-approve-action@v3
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.AUTO_APPROVE_PAT || secrets.GITHUB_TOKEN }}
+      - name: Checkout base branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - name: Fetch pull request branch
+        run: |
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr
+      - name: Merge pull request preferring theirs
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git merge pr -X theirs -m "Auto merge PR #${{ github.event.pull_request.number }}"
+      - name: Push changes
+        run: git push origin HEAD:${{ github.event.pull_request.base.ref }}
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to automatically approve and merge pull requests using the incoming PR's version when conflicts arise
- grant write permissions to allow pushes during `pull_request_target` runs
- tolerate auto-approve failures and support alternate token via `AUTO_APPROVE_PAT`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a8c01691c832081aaa42ffb6d5390