### PR TITLE
Improve navigation links

### DIFF
--- a/availability.html
+++ b/availability.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
@@ -17,7 +18,7 @@
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
-          <div class="flex items-center gap-4 text-white">
+          <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -27,15 +28,16 @@
               </svg>
             </div>
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
-          </div>
+          </a>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="#">Home</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Create</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Help</a>
+              <a class="text-white text-sm font-medium leading-normal" href="index.html">Home</a>
+              <a class="text-white text-sm font-medium leading-normal" href="create-event.html">Create</a>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Help</span>
             </div>
             <button
-              class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 bg-[#29382f] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+              class="flex max-w-[480px] cursor-not-allowed items-center justify-center overflow-hidden rounded-full h-10 bg-gray-500 text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+              disabled
             >
               <div class="text-white" data-icon="Question" data-size="20px" data-weight="regular">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">

--- a/create-event.html
+++ b/create-event.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
@@ -20,7 +21,7 @@
     >
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
-          <div class="flex items-center gap-4 text-white">
+          <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -30,16 +31,17 @@
               </svg>
             </div>
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
-          </div>
+          </a>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="#">Dashboard</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Availability</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Integrations</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Help</a>
+              <a class="text-white text-sm font-medium leading-normal" href="dashboard.html">Dashboard</a>
+              <a class="text-white text-sm font-medium leading-normal" href="availability.html">Availability</a>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Integrations</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Help</span>
             </div>
             <button
-              class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 bg-[#29382f] text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+              class="flex max-w-[480px] cursor-not-allowed items-center justify-center overflow-hidden rounded-full h-10 bg-gray-500 text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+              disabled
             >
               <div class="text-white" data-icon="Question" data-size="20px" data-weight="regular">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
@@ -121,7 +123,8 @@
             </div>
             <div class="flex px-4 py-3 justify-end">
               <button
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
+                class="flex min-w-[84px] max-w-[480px] cursor-not-allowed items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-gray-500 text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
+                disabled
               >
                 <span class="truncate">Next</span>
               </button>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
@@ -17,7 +18,7 @@
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
-          <div class="flex items-center gap-4 text-white">
+          <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -27,18 +28,19 @@
               </svg>
             </div>
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
-          </div>
+          </a>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="#">Individuals</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Teams</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Enterprise</a>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Individuals</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Teams</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Enterprise</span>
             </div>
-            <button
+            <a
+              href="log-in.html"
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
             >
               <span class="truncate">Log in</span>
-            </button>
+            </a>
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">

--- a/get-started.html
+++ b/get-started.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
@@ -17,7 +18,7 @@
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
-          <div class="flex items-center gap-4 text-white">
+          <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -27,18 +28,19 @@
               </svg>
             </div>
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
-          </div>
+          </a>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="#">Individuals</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Teams</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Enterprise</a>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Individuals</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Teams</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Enterprise</span>
             </div>
-            <button
+            <a
+              href="log-in.html"
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
             >
               <span class="truncate">Log in</span>
-            </button>
+            </a>
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
@@ -81,11 +83,12 @@
               </label>
             </div>
             <div class="flex px-4 py-3">
-              <button
+              <a
+                href="dashboard.html"
                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 flex-1 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
               >
                 <span class="truncate">Sign up</span>
-              </button>
+              </a>
             </div>
             <p class="text-[#9eb7a8] text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center">By signing up, you agree to our Terms of Service and Privacy Policy.</p>
             <p class="text-[#9eb7a8] text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center">

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
@@ -17,7 +18,7 @@
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
-          <div class="flex items-center gap-4 text-white">
+          <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -27,25 +28,27 @@
               </svg>
             </div>
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
-          </div>
+          </a>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="#">Product</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Solutions</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Resources</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Pricing</a>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Product</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Solutions</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Resources</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Pricing</span>
             </div>
             <div class="flex gap-2">
-              <button
+              <a
+                href="get-started.html"
                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
               >
                 <span class="truncate">Sign up</span>
-              </button>
-              <button
+              </a>
+              <a
+                href="log-in.html"
                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#29382f] text-white text-sm font-bold leading-normal tracking-[0.015em]"
               >
                 <span class="truncate">Log in</span>
-              </button>
+              </a>
             </div>
           </div>
         </header>
@@ -67,11 +70,12 @@
                       Calendarify is the modern scheduling platform that makes scheduling easy. Say goodbye to phone and email tag for finding the perfect time.
                     </h2>
                   </div>
-                  <button
+                  <a
+                    href="get-started.html"
                     class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 @[480px]:h-12 @[480px]:px-5 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em] @[480px]:text-base @[480px]:font-bold @[480px]:leading-normal @[480px]:tracking-[0.015em]"
                   >
                     <span class="truncate">Get started</span>
-                  </button>
+                  </a>
                 </div>
               </div>
             </div>

--- a/log-in.html
+++ b/log-in.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
@@ -17,7 +18,7 @@
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
-          <div class="flex items-center gap-4 text-white">
+          <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -27,18 +28,19 @@
               </svg>
             </div>
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
-          </div>
+          </a>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="#">Individuals</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Teams</a>
-              <a class="text-white text-sm font-medium leading-normal" href="#">Enterprise</a>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Individuals</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Teams</span>
+              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Enterprise</span>
             </div>
-            <button
+            <a
+              href="log-in.html"
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
             >
               <span class="truncate">Log in</span>
-            </button>
+            </a>
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
@@ -81,11 +83,12 @@
               </label>
             </div>
             <div class="flex px-4 py-3">
-              <button
+              <a
+                href="dashboard.html"
                 class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 flex-1 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
               >
                 <span class="truncate">Sign up</span>
-              </button>
+              </a>
             </div>
             <p class="text-[#9eb7a8] text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center">By signing up, you agree to our Terms of Service and Privacy Policy.</p>
             <p class="text-[#9eb7a8] text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center">


### PR DESCRIPTION
## Summary
- add `DOCTYPE` declarations
- disable and grey out unused menu items
- link signup and login buttons to real pages
- disable unfinished actions
- make logo link to home on each page

## Testing
- `tidy -e availability.html`
- `tidy -e create-event.html`
- `tidy -e dashboard.html`
- `tidy -e get-started.html`
- `tidy -e index.html`
- `tidy -e log-in.html`


------
https://chatgpt.com/codex/tasks/task_e_684a97b879f08320b8555f094775e032