### PR TITLE
Unify navbar across pages

### DIFF
--- a/availability.html
+++ b/availability.html
@@ -13,11 +13,36 @@
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+      .nav-indicator {
+        position: absolute;
+        bottom: -3px;
+        height: 2px;
+        background-color: #38e07b;
+        transition: all 0.3s ease;
+        left: 0;
+        width: 0;
+      }
+      .nav-link {
+        position: relative;
+        color: #9eb7a8;
+        transition: color 0.3s ease;
+      }
+      .nav-link:hover {
+        color: #38e07b;
+      }
+      .nav-link.active {
+        color: #38e07b;
+      }
+      .nav-container {
+        position: relative;
+      }
+    </style>
   </head>
   <body>
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
-        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
+        <header class="sticky top-0 z-50 flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3 bg-[#111714]">
           <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -30,27 +55,28 @@
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
           </a>
           <div class="flex flex-1 justify-end gap-8">
-            <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="index.html">Home</a>
-              <a class="text-white text-sm font-medium leading-normal" href="create-event.html">Create</a>
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Help</span>
+            <div class="nav-container flex items-center gap-9 relative">
+              <a class="nav-link active text-white text-sm font-medium leading-normal" href="index.html">Home</a>
+              <a class="nav-link text-white text-sm font-medium leading-normal" href="create-event.html">Create</a>
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Help</span>
+              <button
+                class="flex max-w-[480px] cursor-not-allowed items-center justify-center overflow-hidden rounded-full h-10 bg-gray-500 text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+                disabled
+              >
+                <div class="text-white" data-icon="Question" data-size="20px" data-weight="regular">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+                    <path
+                      d="M140,180a12,12,0,1,1-12-12A12,12,0,0,1,140,180ZM128,72c-22.06,0-40,16.15-40,36v4a8,8,0,0,0,16,0v-4c0-11,10.77-20,24-20s24,9,24,20-10.77,20-24,20a8,8,0,0,0-8,8v8a8,8,0,0,0,16,0v-.72c18.24-3.35,32-17.9,32-35.28C168,88.15,150.06,72,128,72Zm104,56A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z"
+                    ></path>
+                  </svg>
+                </div>
+              </button>
+              <div
+                class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
+                style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBZRGlFUvr4PcflwsRafD3Vr3HvVOO5JPTQ8PvR-bObdKsuzA28l29hP-k8L3S59LPYAxKR-CX3BZEXqaWhBwKI-xMBmx-XxDS5wx9bdxcVLOzuAhp0CLWRxUY57N_jcZPISrIiQJDaRU8kFtSVoX1NLYCr0dFW1yOHw2iByxwY5VXl5YbEXDTaIrkCtcaZIfEYT8_7cIePIJOXioD0HDEed9LGeL1Mlg3ugoCrEdDEkpLEfOH020I--0PJALX6rTPh3Gm2hDwLbhcd");'
+              ></div>
+              <div class="nav-indicator" id="navIndicator"></div>
             </div>
-            <button
-              class="flex max-w-[480px] cursor-not-allowed items-center justify-center overflow-hidden rounded-full h-10 bg-gray-500 text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
-              disabled
-            >
-              <div class="text-white" data-icon="Question" data-size="20px" data-weight="regular">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
-                  <path
-                    d="M140,180a12,12,0,1,1-12-12A12,12,0,0,1,140,180ZM128,72c-22.06,0-40,16.15-40,36v4a8,8,0,0,0,16,0v-4c0-11,10.77-20,24-20s24,9,24,20-10.77,20-24,20a8,8,0,0,0-8,8v8a8,8,0,0,0,16,0v-.72c18.24-3.35,32-17.9,32-35.28C168,88.15,150.06,72,128,72Zm104,56A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z"
-                  ></path>
-                </svg>
-              </div>
-            </button>
-            <div
-              class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuBZRGlFUvr4PcflwsRafD3Vr3HvVOO5JPTQ8PvR-bObdKsuzA28l29hP-k8L3S59LPYAxKR-CX3BZEXqaWhBwKI-xMBmx-XxDS5wx9bdxcVLOzuAhp0CLWRxUY57N_jcZPISrIiQJDaRU8kFtSVoX1NLYCr0dFW1yOHw2iByxwY5VXl5YbEXDTaIrkCtcaZIfEYT8_7cIePIJOXioD0HDEed9LGeL1Mlg3ugoCrEdDEkpLEfOH020I--0PJALX6rTPh3Gm2hDwLbhcd");'
-            ></div>
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
@@ -266,5 +292,52 @@
         </div>
       </div>
     </div>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        const navLinks = document.querySelectorAll('.nav-link');
+        const indicator = document.getElementById('navIndicator');
+        let activeLink = document.querySelector('.nav-link.active');
+        let hoveredLink = null;
+
+        function updateIndicator(element) {
+          if (!element) return;
+
+          const rect = element.getBoundingClientRect();
+          const container = element.closest('.nav-container');
+          const containerRect = container.getBoundingClientRect();
+
+          indicator.style.width = `${rect.width}px`;
+          indicator.style.left = `${rect.left - containerRect.left}px`;
+        }
+
+        if (activeLink) {
+          requestAnimationFrame(() => {
+            updateIndicator(activeLink);
+          });
+        }
+
+        navLinks.forEach(link => {
+          link.addEventListener('mouseenter', () => {
+            hoveredLink = link;
+            updateIndicator(link);
+          });
+
+          link.addEventListener('mouseleave', () => {
+            hoveredLink = null;
+            if (activeLink) {
+              updateIndicator(activeLink);
+            }
+          });
+        });
+
+        window.addEventListener('resize', () => {
+          if (hoveredLink) {
+            updateIndicator(hoveredLink);
+          } else if (activeLink) {
+            updateIndicator(activeLink);
+          }
+        });
+      });
+    </script>
   </body>
 </html>

--- a/create-event.html
+++ b/create-event.html
@@ -13,6 +13,31 @@
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+      .nav-indicator {
+        position: absolute;
+        bottom: -3px;
+        height: 2px;
+        background-color: #38e07b;
+        transition: all 0.3s ease;
+        left: 0;
+        width: 0;
+      }
+      .nav-link {
+        position: relative;
+        color: #9eb7a8;
+        transition: color 0.3s ease;
+      }
+      .nav-link:hover {
+        color: #38e07b;
+      }
+      .nav-link.active {
+        color: #38e07b;
+      }
+      .nav-container {
+        position: relative;
+      }
+    </style>
   </head>
   <body>
     <div
@@ -20,7 +45,7 @@
       style='--select-button-svg: url(&apos;data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(158,183,168)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e&apos;); font-family: "Spline Sans", "Noto Sans", sans-serif;'
     >
       <div class="layout-container flex h-full grow flex-col">
-        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
+        <header class="sticky top-0 z-50 flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3 bg-[#111714]">
           <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -33,28 +58,29 @@
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
           </a>
           <div class="flex flex-1 justify-end gap-8">
-            <div class="flex items-center gap-9">
-              <a class="text-white text-sm font-medium leading-normal" href="dashboard.html">Dashboard</a>
-              <a class="text-white text-sm font-medium leading-normal" href="availability.html">Availability</a>
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Integrations</span>
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Help</span>
+            <div class="nav-container flex items-center gap-9 relative">
+              <a class="nav-link active text-white text-sm font-medium leading-normal" href="dashboard.html">Dashboard</a>
+              <a class="nav-link text-white text-sm font-medium leading-normal" href="availability.html">Availability</a>
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Integrations</span>
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Help</span>
+              <button
+                class="flex max-w-[480px] cursor-not-allowed items-center justify-center overflow-hidden rounded-full h-10 bg-gray-500 text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
+                disabled
+              >
+                <div class="text-white" data-icon="Question" data-size="20px" data-weight="regular">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
+                    <path
+                      d="M140,180a12,12,0,1,1-12-12A12,12,0,0,1,140,180ZM128,72c-22.06,0-40,16.15-40,36v4a8,8,0,0,0,16,0v-4c0-11,10.77-20,24-20s24,9,24,20-10.77,20-24,20a8,8,0,0,0-8,8v8a8,8,0,0,0,16,0v-.72c18.24-3.35,32-17.9,32-35.28C168,88.15,150.06,72,128,72Zm104,56A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z"
+                    ></path>
+                  </svg>
+                </div>
+              </button>
+              <div
+                class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
+                style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuChybXieopZjwcb06x0zQJJYv4ArW6S5ZDXb8p6FzbFSewKq4HKFMTZb8HwI0t4fq-CZqmU6HqNgrqLtKWwmF5x-625SwT2T2pPdf8m3IBD8HiW4L36YJMr3DMRKxzCqjcJfYqNkHn8bOCX48cv7IiRfEvsvyX6f0fd7u8ypT1iwqMiejwjGmWvu5YC4THluaEDH1KpHGhw_lQv-5o4SqSGWkL3gjOgiEUqbPSjYuc9YOT3S-v3_hQCvRL2kMkgKOfhX0BxBui0fpYK");'
+              ></div>
+              <div class="nav-indicator" id="navIndicator"></div>
             </div>
-            <button
-              class="flex max-w-[480px] cursor-not-allowed items-center justify-center overflow-hidden rounded-full h-10 bg-gray-500 text-white gap-2 text-sm font-bold leading-normal tracking-[0.015em] min-w-0 px-2.5"
-              disabled
-            >
-              <div class="text-white" data-icon="Question" data-size="20px" data-weight="regular">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="currentColor" viewBox="0 0 256 256">
-                  <path
-                    d="M140,180a12,12,0,1,1-12-12A12,12,0,0,1,140,180ZM128,72c-22.06,0-40,16.15-40,36v4a8,8,0,0,0,16,0v-4c0-11,10.77-20,24-20s24,9,24,20-10.77,20-24,20a8,8,0,0,0-8,8v8a8,8,0,0,0,16,0v-.72c18.24-3.35,32-17.9,32-35.28C168,88.15,150.06,72,128,72Zm104,56A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z"
-                  ></path>
-                </svg>
-              </div>
-            </button>
-            <div
-              class="bg-center bg-no-repeat aspect-square bg-cover rounded-full size-10"
-              style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuChybXieopZjwcb06x0zQJJYv4ArW6S5ZDXb8p6FzbFSewKq4HKFMTZb8HwI0t4fq-CZqmU6HqNgrqLtKWwmF5x-625SwT2T2pPdf8m3IBD8HiW4L36YJMr3DMRKxzCqjcJfYqNkHn8bOCX48cv7IiRfEvsvyX6f0fd7u8ypT1iwqMiejwjGmWvu5YC4THluaEDH1KpHGhw_lQv-5o4SqSGWkL3gjOgiEUqbPSjYuc9YOT3S-v3_hQCvRL2kMkgKOfhX0BxBui0fpYK");'
-            ></div>
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
@@ -136,5 +162,52 @@
         </div>
       </div>
     </div>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        const navLinks = document.querySelectorAll('.nav-link');
+        const indicator = document.getElementById('navIndicator');
+        let activeLink = document.querySelector('.nav-link.active');
+        let hoveredLink = null;
+
+        function updateIndicator(element) {
+          if (!element) return;
+
+          const rect = element.getBoundingClientRect();
+          const container = element.closest('.nav-container');
+          const containerRect = container.getBoundingClientRect();
+
+          indicator.style.width = `${rect.width}px`;
+          indicator.style.left = `${rect.left - containerRect.left}px`;
+        }
+
+        if (activeLink) {
+          requestAnimationFrame(() => {
+            updateIndicator(activeLink);
+          });
+        }
+
+        navLinks.forEach(link => {
+          link.addEventListener('mouseenter', () => {
+            hoveredLink = link;
+            updateIndicator(link);
+          });
+
+          link.addEventListener('mouseleave', () => {
+            hoveredLink = null;
+            if (activeLink) {
+              updateIndicator(activeLink);
+            }
+          });
+        });
+
+        window.addEventListener('resize', () => {
+          if (hoveredLink) {
+            updateIndicator(hoveredLink);
+          } else if (activeLink) {
+            updateIndicator(activeLink);
+          }
+        });
+      });
+    </script>
   </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -13,11 +13,36 @@
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+      .nav-indicator {
+        position: absolute;
+        bottom: -3px;
+        height: 2px;
+        background-color: #38e07b;
+        transition: all 0.3s ease;
+        left: 0;
+        width: 0;
+      }
+      .nav-link {
+        position: relative;
+        color: #9eb7a8;
+        transition: color 0.3s ease;
+      }
+      .nav-link:hover {
+        color: #38e07b;
+      }
+      .nav-link.active {
+        color: #38e07b;
+      }
+      .nav-container {
+        position: relative;
+      }
+    </style>
   </head>
   <body>
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
-        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
+        <header class="sticky top-0 z-50 flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3 bg-[#111714]">
           <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -30,17 +55,18 @@
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
           </a>
           <div class="flex flex-1 justify-end gap-8">
-            <div class="flex items-center gap-9">
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Individuals</span>
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Teams</span>
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Enterprise</span>
+            <div class="nav-container flex items-center gap-9 relative">
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Individuals</span>
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Teams</span>
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Enterprise</span>
+              <a
+                href="log-in.html"
+                class="nav-link active flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
+              >
+                <span class="truncate text-[#111714]">Log in</span>
+              </a>
+              <div class="nav-indicator" id="navIndicator"></div>
             </div>
-            <a
-              href="log-in.html"
-              class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
-            >
-              <span class="truncate">Log in</span>
-            </a>
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
@@ -97,5 +123,52 @@
         </div>
       </div>
     </div>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        const navLinks = document.querySelectorAll('.nav-link');
+        const indicator = document.getElementById('navIndicator');
+        let activeLink = document.querySelector('.nav-link.active');
+        let hoveredLink = null;
+
+        function updateIndicator(element) {
+          if (!element) return;
+
+          const rect = element.getBoundingClientRect();
+          const container = element.closest('.nav-container');
+          const containerRect = container.getBoundingClientRect();
+
+          indicator.style.width = `${rect.width}px`;
+          indicator.style.left = `${rect.left - containerRect.left}px`;
+        }
+
+        if (activeLink) {
+          requestAnimationFrame(() => {
+            updateIndicator(activeLink);
+          });
+        }
+
+        navLinks.forEach(link => {
+          link.addEventListener('mouseenter', () => {
+            hoveredLink = link;
+            updateIndicator(link);
+          });
+
+          link.addEventListener('mouseleave', () => {
+            hoveredLink = null;
+            if (activeLink) {
+              updateIndicator(activeLink);
+            }
+          });
+        });
+
+        window.addEventListener('resize', () => {
+          if (hoveredLink) {
+            updateIndicator(hoveredLink);
+          } else if (activeLink) {
+            updateIndicator(activeLink);
+          }
+        });
+      });
+    </script>
   </body>
 </html>

--- a/get-started.html
+++ b/get-started.html
@@ -13,6 +13,31 @@
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+      .nav-indicator {
+        position: absolute;
+        bottom: -3px;
+        height: 2px;
+        background-color: #38e07b;
+        transition: all 0.3s ease;
+        left: 0;
+        width: 0;
+      }
+      .nav-link {
+        position: relative;
+        color: #9eb7a8;
+        transition: color 0.3s ease;
+      }
+      .nav-link:hover {
+        color: #38e07b;
+      }
+      .nav-link.active {
+        color: #38e07b;
+      }
+      .nav-container {
+        position: relative;
+      }
+    </style>
   </head>
   <body>
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
@@ -104,6 +129,53 @@
           </p>
           </div>
         </div>
-      </div>
+    </div>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        const navLinks = document.querySelectorAll('.nav-link');
+        const indicator = document.getElementById('navIndicator');
+        let activeLink = document.querySelector('.nav-link.active');
+        let hoveredLink = null;
+
+        function updateIndicator(element) {
+          if (!element) return;
+
+          const rect = element.getBoundingClientRect();
+          const container = element.closest('.nav-container');
+          const containerRect = container.getBoundingClientRect();
+
+          indicator.style.width = `${rect.width}px`;
+          indicator.style.left = `${rect.left - containerRect.left}px`;
+        }
+
+        if (activeLink) {
+          requestAnimationFrame(() => {
+            updateIndicator(activeLink);
+          });
+        }
+
+        navLinks.forEach(link => {
+          link.addEventListener('mouseenter', () => {
+            hoveredLink = link;
+            updateIndicator(link);
+          });
+
+          link.addEventListener('mouseleave', () => {
+            hoveredLink = null;
+            if (activeLink) {
+              updateIndicator(activeLink);
+            }
+          });
+        });
+
+        window.addEventListener('resize', () => {
+          if (hoveredLink) {
+            updateIndicator(hoveredLink);
+          } else if (activeLink) {
+            updateIndicator(activeLink);
+          }
+        });
+      });
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,11 +13,36 @@
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+      .nav-indicator {
+        position: absolute;
+        bottom: -3px;
+        height: 2px;
+        background-color: #38e07b;
+        transition: all 0.3s ease;
+        left: 0;
+        width: 0;
+      }
+      .nav-link {
+        position: relative;
+        color: #9eb7a8;
+        transition: color 0.3s ease;
+      }
+      .nav-link:hover {
+        color: #38e07b;
+      }
+      .nav-link.active {
+        color: #38e07b;
+      }
+      .nav-container {
+        position: relative;
+      }
+    </style>
   </head>
   <body>
     <div class="relative flex size-full min-h-screen flex-col bg-[#111714] dark group/design-root overflow-x-hidden" style='font-family: "Spline Sans", "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
-        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3">
+        <header class="sticky top-0 z-50 flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#29382f] px-10 py-3 bg-[#111714]">
           <a href="index.html" class="flex items-center gap-4 text-white">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -30,25 +55,24 @@
             <h2 class="text-white text-lg font-bold leading-tight tracking-[-0.015em]">Calendarify</h2>
           </a>
           <div class="flex flex-1 justify-end gap-8">
-            <div class="flex items-center gap-9">
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Product</span>
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Solutions</span>
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Resources</span>
-              <span class="text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Pricing</span>
-            </div>
-            <div class="flex gap-2">
+            <div class="nav-container flex items-center gap-9 relative">
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Product</span>
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Solutions</span>
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Resources</span>
+              <span class="nav-link text-gray-500 text-sm font-medium leading-normal cursor-not-allowed">Pricing</span>
               <a
                 href="get-started.html"
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
+                class="nav-link active flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#38e07b] text-[#111714] text-sm font-bold leading-normal tracking-[0.015em]"
               >
-                <span class="truncate">Sign up</span>
+                <span class="truncate text-[#111714]">Sign up</span>
               </a>
               <a
                 href="log-in.html"
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#29382f] text-white text-sm font-bold leading-normal tracking-[0.015em]"
+                class="nav-link flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-transparent border border-[#38e07b] text-[#38e07b] text-sm font-bold leading-normal tracking-[0.015em] hover:bg-[#38e07b] hover:text-[#111714] transition-colors"
               >
                 <span class="truncate">Log in</span>
               </a>
+              <div class="nav-indicator" id="navIndicator"></div>
             </div>
           </div>
         </header>
@@ -86,5 +110,52 @@
         </div>
       </div>
     </div>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        const navLinks = document.querySelectorAll('.nav-link');
+        const indicator = document.getElementById('navIndicator');
+        let activeLink = document.querySelector('.nav-link.active');
+        let hoveredLink = null;
+
+        function updateIndicator(element) {
+          if (!element) return;
+
+          const rect = element.getBoundingClientRect();
+          const container = element.closest('.nav-container');
+          const containerRect = container.getBoundingClientRect();
+
+          indicator.style.width = `${rect.width}px`;
+          indicator.style.left = `${rect.left - containerRect.left}px`;
+        }
+
+        if (activeLink) {
+          requestAnimationFrame(() => {
+            updateIndicator(activeLink);
+          });
+        }
+
+        navLinks.forEach(link => {
+          link.addEventListener('mouseenter', () => {
+            hoveredLink = link;
+            updateIndicator(link);
+          });
+
+          link.addEventListener('mouseleave', () => {
+            hoveredLink = null;
+            if (activeLink) {
+              updateIndicator(activeLink);
+            }
+          });
+        });
+
+        window.addEventListener('resize', () => {
+          if (hoveredLink) {
+            updateIndicator(hoveredLink);
+          } else if (activeLink) {
+            updateIndicator(activeLink);
+          }
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- standardize header positioning on all pages
- reuse the highlighted navbar style and indicator from the log-in page
- mark active link on each page
- add indicator script on every page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ac6f7bc50832087b54e1b1580f5f3