### PR TITLE
Fix meetings nav highlight persistence

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1221,8 +1221,6 @@
       const secEl = document.getElementById(section + '-section');
       if (secEl) secEl.style.display = 'block';
       
-      // Save the active section to localStorage
-      localStorage.setItem('calendarify-active-section', section);
       
       // Initialize section-specific functionality
       if (section === 'meetings') {
@@ -1536,16 +1534,9 @@
       setupTimeInputListeners();
       // Remove all active classes from nav items
       document.querySelectorAll('.nav-item').forEach(item => item.classList.remove('active'));
-      // Restore the last active section from localStorage
-      const activeSection = localStorage.getItem('calendarify-active-section');
-      const navItem = activeSection ? document.querySelector(`.nav-item[data-section="${activeSection}"]`) : null;
-      if (activeSection && navItem) {
-        // Restore the last active section
-        showSection(activeSection, navItem);
-      } else {
-        // Default to event-types if no stored section or invalid section
-        const defaultNav = document.querySelector('.nav-item[data-section="event-types"]');
-        if (defaultNav) showSection('event-types', defaultNav);
+      const defaultNav = document.querySelector('.nav-item[data-section="event-types"]');
+      if (defaultNav) {
+        showSection('event-types', defaultNav);
       }
     });
 


### PR DESCRIPTION
## Summary
- remove localStorage use when changing dashboard sections
- always start on Event Types when loading the dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff9e7ca4832097dcf0e2aeb96167