### PR TITLE
Implement routing form editor

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1207,7 +1207,7 @@
       <section id="routing-section" style="display:none;">
         <div class="flex justify-between items-center mb-6">
           <h2 class="text-2xl font-bold text-white">Routing Forms</h2>
-          <button class="bg-[#34D399] text-[#1A2E29] px-4 py-2 rounded-lg hover:bg-[#2C4A43] transition-colors text-sm font-bold flex items-center gap-2" onclick="openCreateRoutingModal()">
+          <button class="bg-[#34D399] text-[#1A2E29] px-4 py-2 rounded-lg hover:bg-[#2C4A43] transition-colors text-sm font-bold flex items-center gap-2" onclick="createRoutingForm()">
             <span class="material-icons-outlined">add</span>
             Create Routing Form
           </button>
@@ -3885,46 +3885,14 @@
       }).join('');
     }
 
-    function openCreateRoutingModal() {
-      document.getElementById('modal-backdrop').classList.remove('hidden');
-      document.getElementById('create-routing-modal').classList.remove('hidden');
-      document.getElementById('routing-name').value = '';
-      window.editingRoutingId = null;
-    }
-
-    function closeCreateRoutingModal() {
-      document.getElementById('modal-backdrop').classList.add('hidden');
-      document.getElementById('create-routing-modal').classList.add('hidden');
-    }
-
-    function saveRoutingForm() {
-      const name = document.getElementById('routing-name').value.trim();
-      if (!name) {
-        showNotification('Form name required');
-        return;
-      }
-      let forms = JSON.parse(localStorage.getItem('calendarify-routing-forms') || '[]');
-      if (window.editingRoutingId) {
-        const f = forms.find(r => r.id === window.editingRoutingId);
-        if (f) f.name = name;
-        window.editingRoutingId = null;
-      } else {
-        forms.push({ id: Date.now().toString(), name, created: new Date().toISOString() });
-      }
-      localStorage.setItem('calendarify-routing-forms', JSON.stringify(forms));
-      closeCreateRoutingModal();
-      renderRoutingForms();
-      showNotification('Routing form saved');
+    function createRoutingForm() {
+      localStorage.removeItem('calendarify-current-routing');
+      window.location.href = '/dashboard/routing-editor';
     }
 
     function editRoutingForm(id) {
-      const forms = JSON.parse(localStorage.getItem('calendarify-routing-forms') || '[]');
-      const f = forms.find(r => r.id === id);
-      if (!f) return;
-      window.editingRoutingId = id;
-      document.getElementById('routing-name').value = f.name;
-      document.getElementById('modal-backdrop').classList.remove('hidden');
-      document.getElementById('create-routing-modal').classList.remove('hidden');
+      localStorage.setItem('calendarify-current-routing', id);
+      window.location.href = '/dashboard/routing-editor';
     }
 
     function deleteRoutingForm(id) {
@@ -4748,26 +4716,6 @@
     </div>
   </div>
 
-  <!-- Create Routing Form Modal -->
-  <div id="create-routing-modal" class="fixed inset-0 z-50 hidden">
-    <div class="flex items-center justify-center min-h-screen p-4">
-      <div class="bg-[#1E3A34] rounded-xl shadow-2xl w-full max-w-sm">
-        <div class="flex items-center justify-between p-6 border-b border-[#2C4A43]">
-          <h2 class="text-xl font-bold text-white">Create Routing Form</h2>
-          <button onclick="closeCreateRoutingModal()" class="text-[#A3B3AF] hover:text-white transition-colors">
-            <span class="material-icons-outlined text-2xl">close</span>
-          </button>
-        </div>
-        <div class="p-6 space-y-4">
-          <input type="text" id="routing-name" class="w-full bg-[#19342e] border border-[#2C4A43] text-[#E0E0E0] rounded-lg px-4 py-3 focus:border-[#34D399] focus:ring-2 focus:ring-[#34D399] transition-colors" placeholder="Form Name">
-        </div>
-        <div class="flex items-center justify-end gap-3 p-6 border-t border-[#2C4A43]">
-          <button onclick="closeCreateRoutingModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white transition-colors font-medium">Cancel</button>
-          <button onclick="saveRoutingForm()" class="bg-[#34D399] text-[#1A2E29] px-6 py-3 rounded-lg hover:bg-[#2C4A43] transition-colors font-bold">Save</button>
-        </div>
-      </div>
-    </div>
-  </div>
 
   <!-- Event Types Modal -->
   <div id="event-types-modal" class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-[#1E3A34] rounded-xl p-8 z-50 hidden" style="min-width:400px; max-width:500px; max-height:80vh;">

--- a/dashboard/routing-editor/index.html
+++ b/dashboard/routing-editor/index.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Routing Form Editor - Calendarify</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet" />
+  <style>
+    body { font-family: 'Inter', sans-serif; background-color: #1A2E29; color: #E0E0E0; }
+    .select-field { background:#1E3A34; border:1px solid #2C4A43; border-radius:0.5rem; padding:0.5rem 0.75rem; color:#E0E0E0; }
+    .btn-secondary { background:#19342e; color:#A3B3AF; border:1px solid #2C4A43; padding:0.5rem 1rem; border-radius:0.5rem; font-size:0.875rem; font-weight:500; cursor:pointer; transition:all 0.2s ease; }
+    .btn-secondary:hover { background:#2C4A43; color:#E0E0E0; border-color:#34D399; }
+  </style>
+</head>
+<body class="min-h-screen flex flex-col">
+  <header class="bg-[#111f1c] border-b border-[#1E3A34] px-6 py-4 flex items-center justify-between">
+    <a href="/dashboard" class="flex items-center gap-2 text-[#E0E0E0] hover:text-white">
+      <span class="material-icons-outlined text-[#34D399]">arrow_back</span>
+      <span class="font-medium">Back to Dashboard</span>
+    </a>
+    <h1 class="text-xl font-bold text-white">Routing Form Editor</h1>
+    <button id="save-form" class="bg-[#34D399] text-[#1A2E29] px-4 py-2 rounded-lg font-bold hover:bg-[#2C4A43]">Save</button>
+  </header>
+  <main class="flex-1 overflow-y-auto p-6 space-y-6">
+    <div>
+      <label for="form-name" class="block text-sm text-[#A3B3AF] mb-2">Form Name</label>
+      <input id="form-name" class="select-field w-64" placeholder="Form name">
+    </div>
+    <div>
+      <button id="add-question" class="bg-[#34D399] text-[#1A2E29] px-4 py-2 rounded-lg font-bold hover:bg-[#2C4A43]">Add Question</button>
+    </div>
+    <div id="questions" class="space-y-4"></div>
+  </main>
+
+  <div id="question-modal" class="fixed inset-0 z-50 hidden">
+    <div class="flex items-center justify-center min-h-screen p-4">
+      <div class="bg-[#1E3A34] rounded-xl shadow-2xl w-full max-w-md">
+        <div class="flex items-center justify-between p-6 border-b border-[#2C4A43]">
+          <h2 class="text-xl font-bold text-white" id="qm-title">Question</h2>
+          <button onclick="closeQuestionModal()" class="text-[#A3B3AF] hover:text-white">
+            <span class="material-icons-outlined text-2xl">close</span>
+          </button>
+        </div>
+        <div class="p-6 space-y-4">
+          <input id="question-text" class="w-full select-field" placeholder="Question text">
+          <select id="question-type" class="w-full select-field">
+            <option value="text">Short Answer</option>
+            <option value="choice">Multiple Choice</option>
+          </select>
+          <div id="choice-options" class="space-y-2 hidden">
+            <div class="options-container space-y-2"></div>
+            <button id="add-option" type="button" class="btn-secondary">Add Option</button>
+          </div>
+        </div>
+        <div class="flex items-center justify-end gap-3 p-6 border-t border-[#2C4A43]">
+          <button onclick="closeQuestionModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white">Cancel</button>
+          <button id="question-save" class="bg-[#34D399] text-[#1A2E29] px-6 py-3 rounded-lg font-bold hover:bg-[#2C4A43]">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const nameInput = document.getElementById('form-name');
+    const questionsDiv = document.getElementById('questions');
+    const modal = document.getElementById('question-modal');
+    const qText = document.getElementById('question-text');
+    const qType = document.getElementById('question-type');
+    const qOpts = document.getElementById('choice-options');
+    const addOptionBtn = document.getElementById('add-option');
+    let currentForm = null;
+    let editingIndex = null;
+
+    function loadForm() {
+      const id = localStorage.getItem('calendarify-current-routing');
+      let forms = JSON.parse(localStorage.getItem('calendarify-routing-forms') || '[]');
+      if (id) {
+        currentForm = forms.find(f => f.id === id);
+      }
+      if (!currentForm) {
+        currentForm = { id: Date.now().toString(), name: '', created: new Date().toISOString(), questions: [] };
+        forms.push(currentForm);
+        localStorage.setItem('calendarify-routing-forms', JSON.stringify(forms));
+        localStorage.setItem('calendarify-current-routing', currentForm.id);
+      }
+      nameInput.value = currentForm.name || '';
+      renderQuestions();
+    }
+
+    function renderQuestions() {
+      questionsDiv.innerHTML = '';
+      currentForm.questions.forEach((q, i) => {
+        const div = document.createElement('div');
+        div.className = 'p-4 bg-[#1E3A34] rounded-lg flex justify-between items-start';
+        const info = document.createElement('div');
+        const title = document.createElement('p');
+        title.className = 'font-medium';
+        title.textContent = q.text;
+        const type = document.createElement('p');
+        type.className = 'text-sm text-[#A3B3AF]';
+        type.textContent = q.type === 'choice' ? 'Multiple Choice' : 'Short Answer';
+        info.appendChild(title);
+        info.appendChild(type);
+        if (q.type === 'choice' && q.options) {
+          const opts = document.createElement('div');
+          opts.className = 'mt-1 flex flex-wrap gap-1';
+          q.options.forEach(o => {
+            const span = document.createElement('span');
+            span.className = 'bg-[#19342e] text-[#A3B3AF] px-2 py-1 rounded text-xs';
+            span.textContent = o;
+            opts.appendChild(span);
+          });
+          info.appendChild(opts);
+        }
+        const actions = document.createElement('div');
+        actions.className = 'flex gap-2';
+        const editBtn = document.createElement('button');
+        editBtn.className = 'btn-secondary';
+        editBtn.textContent = 'Edit';
+        editBtn.onclick = () => openQuestionModal(i);
+        const delBtn = document.createElement('button');
+        delBtn.className = 'btn-secondary';
+        delBtn.textContent = 'Delete';
+        delBtn.onclick = () => deleteQuestion(i);
+        actions.appendChild(editBtn);
+        actions.appendChild(delBtn);
+        div.appendChild(info);
+        div.appendChild(actions);
+        questionsDiv.appendChild(div);
+      });
+    }
+
+    function openQuestionModal(index = null) {
+      editingIndex = index;
+      if (index !== null) {
+        const q = currentForm.questions[index];
+        qText.value = q.text;
+        qType.value = q.type;
+        populateOptions(q.options || []);
+      } else {
+        qText.value = '';
+        qType.value = 'text';
+        populateOptions([]);
+      }
+      toggleOptions();
+      modal.classList.remove('hidden');
+    }
+
+    function closeQuestionModal() {
+      modal.classList.add('hidden');
+      editingIndex = null;
+    }
+
+    qType.onchange = toggleOptions;
+    function toggleOptions() {
+      if (qType.value === 'choice') {
+        qOpts.classList.remove('hidden');
+      } else {
+        qOpts.classList.add('hidden');
+      }
+    }
+
+    function populateOptions(opts) {
+      const container = qOpts.querySelector('.options-container');
+      container.innerHTML = '';
+      opts.forEach(o => {
+        const row = document.createElement('div');
+        row.className = 'flex gap-2';
+        row.innerHTML = `<input type="text" class="select-field flex-1 option-input" value="${o}" placeholder="Option text"><button type="button" class="btn-secondary remove-option">Remove</button>`;
+        container.appendChild(row);
+      });
+    }
+
+    addOptionBtn.onclick = () => {
+      const container = qOpts.querySelector('.options-container');
+      const row = document.createElement('div');
+      row.className = 'flex gap-2';
+      row.innerHTML = `<input type="text" class="select-field flex-1 option-input" placeholder="Option text"><button type="button" class="btn-secondary remove-option">Remove</button>`;
+      container.appendChild(row);
+    };
+
+    qOpts.addEventListener('click', e => {
+      if (e.target.classList.contains('remove-option')) {
+        e.target.parentElement.remove();
+      }
+    });
+
+    document.getElementById('question-save').onclick = () => {
+      const text = qText.value.trim();
+      if (!text) { alert('Question required'); return; }
+      const type = qType.value;
+      let options = [];
+      if (type === 'choice') {
+        options = Array.from(qOpts.querySelectorAll('.option-input')).map(i => i.value.trim()).filter(Boolean);
+      }
+      const data = { text, type, options };
+      if (editingIndex !== null) {
+        currentForm.questions[editingIndex] = data;
+      } else {
+        currentForm.questions.push(data);
+      }
+      closeQuestionModal();
+      renderQuestions();
+    };
+
+    document.getElementById('add-question').onclick = () => openQuestionModal();
+
+    function deleteQuestion(i) {
+      if (confirm('Delete this question?')) {
+        currentForm.questions.splice(i,1);
+        renderQuestions();
+      }
+    }
+
+    document.getElementById('save-form').onclick = () => {
+      currentForm.name = nameInput.value.trim() || 'Untitled Form';
+      let forms = JSON.parse(localStorage.getItem('calendarify-routing-forms') || '[]');
+      const idx = forms.findIndex(f => f.id === currentForm.id);
+      if (idx !== -1) forms[idx] = currentForm; else forms.push(currentForm);
+      localStorage.setItem('calendarify-routing-forms', JSON.stringify(forms));
+      localStorage.removeItem('calendarify-current-routing');
+      localStorage.setItem('calendarify-redirect-to', 'routing');
+      window.location.href = '/dashboard';
+    };
+
+    document.addEventListener('DOMContentLoaded', loadForm);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new routing form editor page
- replace modal-based routing form creation with link to editor
- hook up routing tab actions to open the editor

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6866734542808320889cd93d0b8247c9