### PR TITLE
Implement simple auth and user data modules

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,8 @@ import { EventTypesModule } from './event-types/event-types.module';
 import { BookingsModule } from './bookings/bookings.module';
 import { AvailabilityModule } from './availability/availability.module';
 import { IntegrationsModule } from './integrations/integrations.module';
+import { ContactsModule } from './contacts/contacts.module';
+import { WorkflowsModule } from './workflows/workflows.module';
 
 @Module({
   imports: [
@@ -19,6 +21,8 @@ import { IntegrationsModule } from './integrations/integrations.module';
     BookingsModule,
     AvailabilityModule,
     IntegrationsModule,
+    ContactsModule,
+    WorkflowsModule,
   ],
   controllers: [AppController],
   providers: [AppService, PrismaService],

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,15 +1,20 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
 
 @Controller('auth')
 export class AuthController {
+  constructor(private auth: AuthService) {}
+
   @Post('register')
-  register(@Body() body: any) {
-    return { message: 'register stub', data: body };
+  register(@Body() dto: RegisterDto) {
+    return this.auth.register(dto);
   }
 
   @Post('login')
-  login(@Body() body: any) {
-    return { message: 'login stub', data: body };
+  login(@Body() dto: LoginDto) {
+    return this.auth.login(dto);
   }
 
   @Post('logout')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,7 +1,14 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
 
 @Module({
+  imports: [PassportModule, JwtModule.register({ secret: process.env.JWT_SECRET || 'changeme' })],
   controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,38 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../prisma.service';
+import * as bcrypt from 'bcrypt';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
 
 @Injectable()
-export class AuthService {}
+export class AuthService {
+  constructor(private prisma: PrismaService, private jwt: JwtService) {}
+
+  async register(data: RegisterDto) {
+    const existing = await this.prisma.user.findUnique({ where: { email: data.email } });
+    if (existing) {
+      throw new UnauthorizedException('Email already registered');
+    }
+    const password = await bcrypt.hash(data.password, 10);
+    const user = await this.prisma.user.create({ data: { email: data.email, password, name: data.name } });
+    return { id: user.id, email: user.email, name: user.name };
+  }
+
+  async validateUser(email: string, password: string) {
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (!user) return null;
+    const valid = await bcrypt.compare(password, user.password);
+    if (valid) return user;
+    return null;
+  }
+
+  async login(data: LoginDto) {
+    const user = await this.validateUser(data.email, data.password);
+    if (!user) throw new UnauthorizedException();
+    const payload = { sub: user.id };
+    return {
+      access_token: await this.jwt.signAsync(payload),
+    };
+  }
+}

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,4 @@
+export class LoginDto {
+  email: string;
+  password: string;
+}

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,0 +1,5 @@
+export class RegisterDto {
+  email: string;
+  password: string;
+  name?: string;
+}

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_SECRET || 'changeme',
+    });
+  }
+
+  async validate(payload: any) {
+    return { userId: payload.sub };
+  }
+}

--- a/backend/src/contacts/contacts.controller.ts
+++ b/backend/src/contacts/contacts.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Get, Post, UseGuards, Request } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ContactsService } from './contacts.service';
+
+@Controller('contacts')
+export class ContactsController {
+  constructor(private contacts: ContactsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  list(@Request() req) {
+    return this.contacts.list(req.user.userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Request() req, @Body() body: { name: string; email: string }) {
+    return this.contacts.create(req.user.userId, body);
+  }
+}

--- a/backend/src/contacts/contacts.module.ts
+++ b/backend/src/contacts/contacts.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ContactsController } from './contacts.controller';
+import { ContactsService } from './contacts.service';
+
+@Module({
+  controllers: [ContactsController],
+  providers: [ContactsService],
+})
+export class ContactsModule {}

--- a/backend/src/contacts/contacts.service.ts
+++ b/backend/src/contacts/contacts.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+export interface Contact {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+}
+
+@Injectable()
+export class ContactsService {
+  private contacts: Contact[] = [];
+
+  list(userId: string) {
+    return this.contacts.filter(c => c.userId === userId);
+  }
+
+  create(userId: string, data: Pick<Contact, 'name' | 'email'>) {
+    const contact = { id: randomUUID(), userId, ...data };
+    this.contacts.push(contact);
+    return contact;
+  }
+}

--- a/backend/src/event-types/event-types.controller.ts
+++ b/backend/src/event-types/event-types.controller.ts
@@ -1,30 +1,39 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards, Request } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { EventTypesService } from './event-types.service';
 
 @Controller('event-types')
 export class EventTypesController {
+  constructor(private events: EventTypesService) {}
+
+  @UseGuards(JwtAuthGuard)
   @Post()
-  create(@Body() body: any) {
-    return { message: 'create event type stub', data: body };
+  create(@Request() req, @Body() body: any) {
+    return this.events.create(req.user.userId, body);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get()
-  findAll() {
-    return [];
+  findAll(@Request() req) {
+    return this.events.list(req.user.userId);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return { id };
+  findOne(@Request() req, @Param('id') id: string) {
+    return this.events.findOne(id);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Patch(':id')
   update(@Param('id') id: string, @Body() body: any) {
-    return { id, data: body };
+    return this.events.update(id, body);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return { id };
+    return this.events.remove(id);
   }
 
   @Get(':slug/slots')

--- a/backend/src/event-types/event-types.module.ts
+++ b/backend/src/event-types/event-types.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { EventTypesController } from './event-types.controller';
+import { EventTypesService } from './event-types.service';
 
 @Module({
   controllers: [EventTypesController],
+  providers: [EventTypesService],
 })
 export class EventTypesModule {}

--- a/backend/src/event-types/event-types.service.ts
+++ b/backend/src/event-types/event-types.service.ts
@@ -1,4 +1,41 @@
 import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+export interface EventType {
+  id: string;
+  userId: string;
+  slug: string;
+  title: string;
+  description?: string;
+  duration: number;
+}
 
 @Injectable()
-export class EventTypesService {}
+export class EventTypesService {
+  private eventTypes: EventType[] = [];
+
+  list(userId: string) {
+    return this.eventTypes.filter(e => e.userId === userId);
+  }
+
+  create(userId: string, data: Omit<EventType, 'id' | 'userId'>) {
+    const event = { id: randomUUID(), userId, ...data };
+    this.eventTypes.push(event);
+    return event;
+  }
+
+  findOne(id: string) {
+    return this.eventTypes.find(e => e.id === id);
+  }
+
+  update(id: string, data: Partial<EventType>) {
+    const idx = this.eventTypes.findIndex(e => e.id === id);
+    if (idx >= 0) this.eventTypes[idx] = { ...this.eventTypes[idx], ...data };
+    return this.eventTypes[idx];
+  }
+
+  remove(id: string) {
+    this.eventTypes = this.eventTypes.filter(e => e.id !== id);
+    return { id };
+  }
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,14 +1,20 @@
-import { Body, Controller, Get, Patch } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { UsersService } from './users.service';
 
 @Controller('users')
 export class UsersController {
+  constructor(private users: UsersService) {}
+
+  @UseGuards(JwtAuthGuard)
   @Get('me')
-  me() {
-    return { user: null };
+  me(@Request() req) {
+    return this.users.findById(req.user.userId);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Patch('me')
-  update(@Body() body: any) {
-    return { message: 'update stub', data: body };
+  update(@Request() req, @Body() body: any) {
+    return this.users.update(req.user.userId, body);
   }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
 
 @Module({
   controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
 })
 export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
 
 @Injectable()
-export class UsersService {}
+export class UsersService {
+  constructor(private prisma: PrismaService) {}
+
+  findById(id: string) {
+    return this.prisma.user.findUnique({ where: { id } });
+  }
+
+  update(id: string, data: any) {
+    return this.prisma.user.update({ where: { id }, data });
+  }
+}

--- a/backend/src/workflows/workflows.controller.ts
+++ b/backend/src/workflows/workflows.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Get, Post, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { WorkflowsService } from './workflows.service';
+
+@Controller('workflows')
+export class WorkflowsController {
+  constructor(private workflows: WorkflowsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  list(@Request() req) {
+    return this.workflows.list(req.user.userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Request() req, @Body() body: { name: string; description?: string }) {
+    return this.workflows.create(req.user.userId, body);
+  }
+}

--- a/backend/src/workflows/workflows.module.ts
+++ b/backend/src/workflows/workflows.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { WorkflowsController } from './workflows.controller';
+import { WorkflowsService } from './workflows.service';
+
+@Module({
+  controllers: [WorkflowsController],
+  providers: [WorkflowsService],
+})
+export class WorkflowsModule {}

--- a/backend/src/workflows/workflows.service.ts
+++ b/backend/src/workflows/workflows.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+export interface Workflow {
+  id: string;
+  userId: string;
+  name: string;
+  description?: string;
+}
+
+@Injectable()
+export class WorkflowsService {
+  private workflows: Workflow[] = [];
+
+  list(userId: string) {
+    return this.workflows.filter(w => w.userId === userId);
+  }
+
+  create(userId: string, data: Pick<Workflow, 'name' | 'description'>) {
+    const workflow = { id: randomUUID(), userId, ...data };
+    this.workflows.push(workflow);
+    return workflow;
+  }
+}


### PR DESCRIPTION
## Summary
- enable JWT auth with registration and login
- protect profile endpoints
- add in-memory storage for contacts, workflows and event types
- wire new modules into the main app

## Testing
- `npx tsc -p backend/tsconfig.json`
- `npm test` *(fails: ts-jest missing peer dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6867b183946c83208fcecea30e93f367