### PR TITLE
Fix run_local.py frontend server start

### DIFF
--- a/run_local.py
+++ b/run_local.py
@@ -154,17 +154,11 @@ def start_backend():
 
 
 def serve_frontend():
-    # Install and use a proper static server that supports clean URLs
+    # Use the Node server that comes with the project to serve the static files
+    # with extensionless URL support.
     def _run():
-        # Try to install serve locally if not available
-        try:
-            subprocess.run(['npx', 'serve', '--version'], capture_output=True, check=True)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            print("Installing serve package locally for better static file serving...")
-            run('npm install serve')
-        
-        # Serve the project root with clean URLs
-        run('npx serve -s . -l 3000 --single')
+        # Use npm start which runs `node server.js`
+        run('npm start')
     t = Thread(target=_run)
     t.daemon = True
     t.start()


### PR DESCRIPTION
## Summary
- fix `run_local.py` so it serves the frontend using the project’s `server.js`

## Testing
- `npm test` *(fails: calendarify@workspace:. not present in lockfile)*
- `yarn install` *(fails to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_6867e9c012ec83209466a2fc22d563e6