### PR TITLE
Implement persistent dashboard state

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -26,6 +26,18 @@ function login(data) {
   return apiRequest('/auth/login', data);
 }
 
+async function loadUserState(token) {
+  const res = await fetch(`${API_URL}/users/me/state`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    Object.entries(data).forEach(([k, v]) => {
+      localStorage.setItem(k, JSON.stringify(v));
+    });
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   console.log('DOM loaded, setting up forms...');
   
@@ -55,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('User registered, logging in...');
         const { access_token } = await login({ email, password });
         localStorage.setItem('calendarify-token', access_token);
+        await loadUserState(access_token);
         window.location.href = '/dashboard';
       } catch (e) {
         console.error('Signup error:', e);
@@ -74,6 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
         const { access_token } = await login({ email, password });
         localStorage.setItem('calendarify-token', access_token);
+        await loadUserState(access_token);
         window.location.href = '/dashboard';
       } catch (e) {
         err.textContent = 'Invalid credentials';

--- a/backend/src/users/user-state.service.ts
+++ b/backend/src/users/user-state.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+@Injectable()
+export class UserStateService {
+  private dir = join(__dirname, '..', '..', 'data');
+
+  async load(userId: string): Promise<any> {
+    try {
+      const content = await fs.readFile(join(this.dir, `${userId}.json`), 'utf8');
+      return JSON.parse(content);
+    } catch (e) {
+      return {};
+    }
+  }
+
+  async save(userId: string, data: any) {
+    await fs.mkdir(this.dir, { recursive: true });
+    await fs.writeFile(
+      join(this.dir, `${userId}.json`),
+      JSON.stringify(data, null, 2),
+      'utf8',
+    );
+  }
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,10 +1,11 @@
 import { Body, Controller, Get, Patch, Request, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { UsersService } from './users.service';
+import { UserStateService } from './user-state.service';
 
 @Controller('users')
 export class UsersController {
-  constructor(private users: UsersService) {}
+  constructor(private users: UsersService, private state: UserStateService) {}
 
   @UseGuards(JwtAuthGuard)
   @Get('me')
@@ -16,5 +17,17 @@ export class UsersController {
   @Patch('me')
   update(@Request() req, @Body() body: any) {
     return this.users.update(req.user.userId, body);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('me/state')
+  getState(@Request() req) {
+    return this.state.load(req.user.userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('me/state')
+  saveState(@Request() req, @Body() body: any) {
+    return this.state.save(req.user.userId, body);
   }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma.service';
+import { UserStateService } from './user-state.service';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService, PrismaService],
-  exports: [UsersService],
+  providers: [UsersService, PrismaService, UserStateService],
+  exports: [UsersService, UserStateService],
 })
 export class UsersModule {}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1406,6 +1406,48 @@
   </div>
 
   <script>
+    const API_URL = 'http://localhost:3001/api';
+
+    function collectState() {
+      const data = {};
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith('calendarify-')) {
+          try {
+            data[key] = JSON.parse(localStorage.getItem(key));
+          } catch {
+            data[key] = localStorage.getItem(key);
+          }
+        }
+      }
+      return data;
+    }
+
+    async function syncState() {
+      const token = localStorage.getItem('calendarify-token');
+      if (!token) return;
+      await fetch(`${API_URL}/users/me/state`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(collectState()),
+      });
+    }
+
+    const _setItem = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = function(k, v) {
+      _setItem(k, v);
+      if (k.startsWith('calendarify-')) syncState();
+    };
+    const _removeItem = localStorage.removeItem.bind(localStorage);
+    localStorage.removeItem = function(k) {
+      _removeItem(k);
+      if (k.startsWith('calendarify-')) syncState();
+    };
+    window.addEventListener('beforeunload', syncState);
+
     // Navigation functionality
     function showSection(section, el) {
       // Remove active class from all nav items


### PR DESCRIPTION
## Summary
- add UserStateService for storing dashboard state on disk
- expose `/users/me/state` to load and save per-user state
- load user state after login and sign up
- sync localStorage changes in dashboard with the backend

## Testing
- `yarn workspace backend test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68680b31dd248320be84179d3b7a5277