### PR TITLE
Fix contacts tags not showing on first load

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1968,6 +1968,8 @@
         showMeetingsTab('upcoming', defaultTab);
       } else if (section === 'availability') {
         initializeCalendar();
+      } else if (section === 'contacts') {
+        renderContacts();
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure contacts are rendered when the contacts section is opened

## Testing
- `yarn test` *(fails: ts-jest tried to access jest-util)*

------
https://chatgpt.com/codex/tasks/task_e_686bca855390832084a4b61b858392d2