### PR TITLE
Fix dashboard auth redirect

### DIFF
--- a/dashboard/editor/index.html
+++ b/dashboard/editor/index.html
@@ -149,8 +149,18 @@
       -moz-appearance: textfield;
     }
   </style>
+  <script>
+    const API_URL = 'http://localhost:3001/api';
+  </script>
+  <script>
+    const t = localStorage.getItem('calendarify-token');
+    if (!t) {
+      window.location.replace('/log-in');
+    }
+  </script>
+  <script src="/auth.js"></script>
 </head>
-<body class="min-h-screen flex flex-col">
+<body id="dashboard-body" class="min-h-screen flex flex-col hidden">
   <header class="bg-[#111f1c] border-b border-[#1E3A34] px-6 py-4 flex items-center justify-between">
     <a href="/dashboard" class="flex items-center gap-2 text-[#E0E0E0] hover:text-white">
       <span class="material-icons-outlined text-[#34D399]">arrow_back</span>
@@ -799,6 +809,13 @@
     }
 
     confirmCancel.addEventListener('click', () => confirmModal.classList.add('hidden'));
+  </script>
+  <script>
+    (async () => {
+      if (await requireAuth()) {
+        document.getElementById('dashboard-body').classList.remove('hidden');
+      }
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the workflow editor redirects unauthenticated visitors

## Testing
- `npm test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686cee0800a88320aeddcedcd9605c17