### PR TITLE
Fix dashboard auth redirect

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -117,5 +117,21 @@ async function requireAuth() {
   return true;
 }
 
+async function initAuth(bodyId, onSuccess) {
+  const t = localStorage.getItem('calendarify-token');
+  if (!t) {
+    window.location.replace('/log-in');
+    return;
+  }
+  if (await requireAuth()) {
+    if (bodyId) {
+      const el = document.getElementById(bodyId);
+      if (el) el.classList.remove('hidden');
+    }
+    if (typeof onSuccess === 'function') onSuccess();
+  }
+}
+
 window.verifyToken = verifyToken;
 window.requireAuth = requireAuth;
+window.initAuth = initAuth;

--- a/dashboard/editor/index.html
+++ b/dashboard/editor/index.html
@@ -149,8 +149,15 @@
       -moz-appearance: textfield;
     }
   </style>
+  <script>
+    window.API_URL = 'http://localhost:3001/api';
+    if (!localStorage.getItem('calendarify-token')) {
+      window.location.replace('/log-in');
+    }
+  </script>
+  <script src="/auth.js" defer></script>
 </head>
-<body class="min-h-screen flex flex-col">
+<body id="dashboard-body" class="min-h-screen flex flex-col hidden">
   <header class="bg-[#111f1c] border-b border-[#1E3A34] px-6 py-4 flex items-center justify-between">
     <a href="/dashboard" class="flex items-center gap-2 text-[#E0E0E0] hover:text-white">
       <span class="material-icons-outlined text-[#34D399]">arrow_back</span>
@@ -799,6 +806,9 @@
     }
 
     confirmCancel.addEventListener('click', () => confirmModal.classList.add('hidden'));
+  </script>
+  <script>
+    initAuth('dashboard-body');
   </script>
 </body>
 </html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1079,15 +1079,12 @@
     }
   </style>
   <script>
-    const API_URL = 'http://localhost:3001/api';
-  </script>
-  <script>
-    const t = localStorage.getItem('calendarify-token');
-    if (!t) {
+    window.API_URL = 'http://localhost:3001/api';
+    if (!localStorage.getItem('calendarify-token')) {
       window.location.replace('/log-in');
     }
   </script>
-  <script src="/auth.js"></script>
+  <script src="/auth.js" defer></script>
 </head>
 <body id="dashboard-body" class="flex min-h-screen hidden">
   <!-- Sidebar -->
@@ -4746,12 +4743,7 @@
       document.getElementById('global-search-results').classList.add('hidden');
     }
 
-    (async () => {
-      if (await requireAuth()) {
-        document.getElementById('dashboard-body').classList.remove('hidden');
-        loadState();
-      }
-    })();
+    initAuth('dashboard-body', loadState);
   </script>
 
   <!-- Create Event Type Modal -->

--- a/log-in/index.html
+++ b/log-in/index.html
@@ -87,7 +87,7 @@
       </div>
     </div>
     <script>
-      const API_URL = 'http://localhost:3001/api';
+      window.API_URL = 'http://localhost:3001/api';
     </script>
     <script src="/auth.js"></script>
   </body>

--- a/sign-up/index.html
+++ b/sign-up/index.html
@@ -159,7 +159,7 @@
       });
     </script>
     <script>
-      const API_URL = 'http://localhost:3001/api';
+      window.API_URL = 'http://localhost:3001/api';
     </script>
     <script src="/auth.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- centralize authentication checks with new `initAuth` helper
- initialize auth in the dashboard and workflow editor pages
- expose `window.API_URL` globally so `auth.js` can verify tokens
- add direct redirect snippet to immediately send users to log in

## Testing
- `npm test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686cee0800a88320aeddcedcd9605c17