### PR TITLE
Implement persistent workflow storage

### DIFF
--- a/backend/prisma/migrations/0002_add_workflows/migration.sql
+++ b/backend/prisma/migrations/0002_add_workflows/migration.sql
@@ -1,0 +1,12 @@
+-- Add workflows table
+CREATE TABLE "Workflow" (
+  "id" UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  "user_id" UUID NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "data" JSONB,
+  "created_at" TIMESTAMP DEFAULT now() NOT NULL,
+  "updated_at" TIMESTAMP DEFAULT now() NOT NULL
+);
+
+CREATE INDEX "Workflow_user_id_idx" ON "Workflow"("user_id");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -136,3 +136,16 @@ model ContactTag {
 
   @@unique([contact_id, tag_id])
 }
+
+model Workflow {
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  user        User     @relation(fields: [user_id], references: [id])
+  user_id     String   @db.Uuid
+  name        String
+  description String?
+  data        Json?
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  @@index([user_id])
+}

--- a/backend/src/event-types/event-types.module.ts
+++ b/backend/src/event-types/event-types.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { EventTypesController } from './event-types.controller';
 import { EventTypesService } from './event-types.service';
+import { PrismaService } from '../prisma.service';
 
 @Module({
   controllers: [EventTypesController],
-  providers: [EventTypesService],
+  providers: [EventTypesService, PrismaService],
 })
 export class EventTypesModule {}

--- a/backend/src/event-types/event-types.service.ts
+++ b/backend/src/event-types/event-types.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { randomUUID } from 'crypto';
+import { PrismaService } from '../prisma.service';
 
 export interface EventType {
   id: string;
@@ -12,30 +12,27 @@ export interface EventType {
 
 @Injectable()
 export class EventTypesService {
-  private eventTypes: EventType[] = [];
+  constructor(private prisma: PrismaService) {}
 
   list(userId: string) {
-    return this.eventTypes.filter(e => e.userId === userId);
+    return this.prisma.eventType.findMany({ where: { user_id: userId }, orderBy: { created_at: 'asc' } });
   }
 
   create(userId: string, data: Omit<EventType, 'id' | 'userId'>) {
-    const event = { id: randomUUID(), userId, ...data };
-    this.eventTypes.push(event);
-    return event;
+    return this.prisma.eventType.create({
+      data: { user_id: userId, ...data },
+    });
   }
 
   findOne(id: string) {
-    return this.eventTypes.find(e => e.id === id);
+    return this.prisma.eventType.findUnique({ where: { id } });
   }
 
   update(id: string, data: Partial<EventType>) {
-    const idx = this.eventTypes.findIndex(e => e.id === id);
-    if (idx >= 0) this.eventTypes[idx] = { ...this.eventTypes[idx], ...data };
-    return this.eventTypes[idx];
+    return this.prisma.eventType.update({ where: { id }, data });
   }
 
   remove(id: string) {
-    this.eventTypes = this.eventTypes.filter(e => e.id !== id);
-    return { id };
+    return this.prisma.eventType.delete({ where: { id } });
   }
 }

--- a/backend/src/workflows/workflows.controller.ts
+++ b/backend/src/workflows/workflows.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Get, Post, Request, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { Patch } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { WorkflowsService } from './workflows.service';
 
@@ -14,7 +15,22 @@ export class WorkflowsController {
 
   @UseGuards(JwtAuthGuard)
   @Post()
-  create(@Request() req, @Body() body: { name: string; description?: string }) {
+  create(
+    @Request() req,
+    @Body() body: { name: string; description?: string; data?: any },
+  ) {
     return this.workflows.create(req.user.userId, body);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id')
+  delete(@Request() req, @Param('id') id: string) {
+    return this.workflows.remove(req.user.userId, id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch(':id')
+  update(@Request() req, @Param('id') id: string, @Body() body: any) {
+    return this.workflows.update(req.user.userId, id, body);
   }
 }

--- a/backend/src/workflows/workflows.module.ts
+++ b/backend/src/workflows/workflows.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { WorkflowsController } from './workflows.controller';
 import { WorkflowsService } from './workflows.service';
+import { PrismaService } from '../prisma.service';
 
 @Module({
   controllers: [WorkflowsController],
-  providers: [WorkflowsService],
+  providers: [WorkflowsService, PrismaService],
 })
 export class WorkflowsModule {}

--- a/backend/src/workflows/workflows.service.ts
+++ b/backend/src/workflows/workflows.service.ts
@@ -1,24 +1,65 @@
 import { Injectable } from '@nestjs/common';
-import { randomUUID } from 'crypto';
+import { PrismaService } from '../prisma.service';
 
 export interface Workflow {
   id: string;
   userId: string;
   name: string;
   description?: string;
+  data?: any;
 }
 
 @Injectable()
 export class WorkflowsService {
-  private workflows: Workflow[] = [];
+  constructor(private prisma: PrismaService) {}
 
-  list(userId: string) {
-    return this.workflows.filter(w => w.userId === userId);
+  async list(userId: string) {
+    const workflows = await this.prisma.workflow.findMany({
+      where: { user_id: userId },
+      orderBy: { created_at: 'asc' },
+    });
+    return workflows.map(w => ({
+      id: w.id,
+      userId: w.user_id,
+      name: w.name,
+      description: w.description || undefined,
+      data: w.data || undefined,
+    }));
   }
 
-  create(userId: string, data: Pick<Workflow, 'name' | 'description'>) {
-    const workflow = { id: randomUUID(), userId, ...data };
-    this.workflows.push(workflow);
-    return workflow;
+  async create(userId: string, data: Pick<Workflow, 'name' | 'description' | 'data'>) {
+    const workflow = await this.prisma.workflow.create({
+      data: {
+        user_id: userId,
+        name: data.name,
+        description: data.description,
+        data: data.data,
+      },
+    });
+    return {
+      id: workflow.id,
+      userId: workflow.user_id,
+      name: workflow.name,
+      description: workflow.description || undefined,
+      data: workflow.data || undefined,
+    };
+  }
+
+  async remove(userId: string, workflowId: string) {
+    await this.prisma.workflow.deleteMany({
+      where: { id: workflowId, user_id: userId },
+    });
+  }
+
+  async update(userId: string, workflowId: string, data: Partial<Workflow>) {
+    await this.prisma.workflow.updateMany({
+      where: { id: workflowId, user_id: userId },
+      data: {
+        name: data.name,
+        description: data.description,
+        data: data.data,
+      },
+    });
+    return this.prisma.workflow.findUnique({ where: { id: workflowId } });
   }
 }

--- a/dashboard/editor/index.html
+++ b/dashboard/editor/index.html
@@ -272,7 +272,7 @@
       renderTriggerProperties();
     });
 
-    saveBtn.addEventListener('click', () => {
+    saveBtn.addEventListener('click', async () => {
       let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
       const steps = Array.from(canvas.querySelectorAll('.step')).map(s => ({
         type: s.dataset.type,
@@ -282,15 +282,26 @@
       const optionsDiv = document.getElementById('event-type-options');
       const triggerEventTypes = optionsDiv ? Array.from(optionsDiv.querySelectorAll('input:checked')).map(cb => cb.value) : [];
       const name = nameInput.value || 'Untitled Workflow';
+      const token = localStorage.getItem('calendarify-token');
+      const clean = token.replace(/^"|"$/g, '');
       if (currentWorkflow) {
         currentWorkflow.name = name;
         currentWorkflow.trigger = trigger;
         currentWorkflow.triggerEventTypes = triggerEventTypes;
         currentWorkflow.steps = steps;
-        currentWorkflow.lastEdited = 'just now';
+        await fetch(`${API_URL}/workflows/${currentWorkflow.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+          body: JSON.stringify({ name, description: currentWorkflow.description, data: currentWorkflow }),
+        });
         workflows = workflows.map(w => w.id === currentWorkflow.id ? currentWorkflow : w);
       } else {
-        currentWorkflow = { id: Date.now().toString(), name, status: true, eventTypes: 'All Event Types', lastEdited: 'just now', trigger, triggerEventTypes, steps };
+        const res = await fetch(`${API_URL}/workflows`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+          body: JSON.stringify({ name, description: '', data: { trigger, triggerEventTypes, steps, status: true } }),
+        });
+        currentWorkflow = await res.json();
         workflows.push(currentWorkflow);
       }
       localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1849,6 +1849,35 @@
       }
     }
 
+    async function fetchTagsFromServer() {
+      const token = localStorage.getItem('calendarify-token');
+      if (!token) return [];
+      const clean = token.replace(/^"|"$/g, '');
+      const res = await fetch(`${API_URL}/tags`, { headers: { Authorization: `Bearer ${clean}` } });
+      if (res.ok) {
+        const tags = await res.json();
+        const map = {};
+        tags.forEach(t => (map[t.name] = t.id));
+        localStorage.setItem('calendarify-tags', JSON.stringify(tags.map(t => t.name)));
+        localStorage.setItem('calendarify-tag-map', JSON.stringify(map));
+        return tags;
+      }
+      return [];
+    }
+
+    async function fetchWorkflowsFromServer() {
+      const token = localStorage.getItem('calendarify-token');
+      if (!token) return [];
+      const clean = token.replace(/^"|"$/g, '');
+      const res = await fetch(`${API_URL}/workflows`, { headers: { Authorization: `Bearer ${clean}` } });
+      if (res.ok) {
+        const wfs = await res.json();
+        localStorage.setItem('calendarify-workflows', JSON.stringify(wfs));
+        return wfs;
+      }
+      return [];
+    }
+
     function collectState() {
       const data = {};
       for (let i = 0; i < localStorage.length; i++) {
@@ -2169,12 +2198,19 @@
       let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
       const wf = workflows.find(w => w.id === id);
       if (!wf) return;
-      const newWf = { ...wf, id: Date.now().toString(), name: wf.name + ' Copy', lastEdited: 'just now' };
-      workflows.push(newWf);
-      localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
-      renderWorkflows();
-      renderContacts();
-      showNotification('Workflow cloned');
+      const token = localStorage.getItem('calendarify-token');
+      const clean = token.replace(/^"|"$/g, '');
+      fetch(`${API_URL}/workflows`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+        body: JSON.stringify({ name: wf.name + ' Copy', description: wf.description, data: wf.data }),
+      }).then(res => res.json()).then(newWf => {
+        workflows.push(newWf);
+        localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
+        renderWorkflows();
+        renderContacts();
+        showNotification('Workflow cloned');
+      });
     }
 
     function deleteWorkflow(id) {
@@ -2186,6 +2222,9 @@
     function confirmDeleteWorkflow() {
       const workflowId = window.workflowToDelete;
       if (workflowId) {
+        const token = localStorage.getItem('calendarify-token');
+        const clean = token.replace(/^"|"$/g, '');
+        fetch(`${API_URL}/workflows/${workflowId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${clean}` } });
         let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
         workflows = workflows.filter(w => w.id !== workflowId);
         localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
@@ -2302,14 +2341,7 @@
 
     function renderWorkflows() {
       const tbody = document.getElementById('workflows-tbody');
-      let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
-      if (workflows.length === 0) {
-        workflows = [
-          { id: 'wf1', name: 'Send Reminder Email', status: true, triggerEventTypes: ['Intro Call'], lastEdited: '2 days ago' },
-          { id: 'wf2', name: 'Post-Meeting SMS', status: false, triggerEventTypes: ['All Event Types'], lastEdited: '1 week ago' }
-        ];
-        localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
-      }
+      let workflows = await fetchWorkflowsFromServer();
       
       function formatEventTypes(eventTypes) {
         if (!eventTypes || eventTypes.length === 0) {
@@ -2582,6 +2614,7 @@
       updateClockFormatUI();
       updateAllCustomTimePickers();
       setupTimeInputListeners();
+      fetchTagsFromServer();
       renderWorkflows();
 
       const avatar = document.getElementById('profile-avatar');
@@ -3767,10 +3800,9 @@
       const container = document.getElementById('contact-tag-options');
       if (!container) return;
       container.innerHTML = '';
-      
+
       try {
-        // Get tags from localStorage
-        const tags = JSON.parse(localStorage.getItem('calendarify-tags') || '[]');
+        const tags = await fetchTagsFromServer();
         
         if (tags.length === 0) {
           container.innerHTML = '<p class="text-[#A3B3AF] text-sm">No tags available</p>';
@@ -3811,22 +3843,23 @@
         showNotification('Tag name required');
         return;
       }
-      
+
       try {
-        // Get existing tags from localStorage
+        const token = localStorage.getItem('calendarify-token');
+        const clean = token.replace(/^"|"$/g, '');
+        const res = await fetch(`${API_URL}/tags`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+          body: JSON.stringify({ name }),
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const tag = await res.json();
         const tags = JSON.parse(localStorage.getItem('calendarify-tags') || '[]');
-        
-        // Check if tag already exists
-        if (tags.includes(name)) {
-          showNotification('Tag already exists');
-          return;
-        }
-        
-        // Add new tag
-        tags.push(name);
-        
-        // Save back to localStorage
+        const map = JSON.parse(localStorage.getItem('calendarify-tag-map') || '{}');
+        if (!tags.includes(tag.name)) tags.push(tag.name);
+        map[tag.name] = tag.id;
         localStorage.setItem('calendarify-tags', JSON.stringify(tags));
+        localStorage.setItem('calendarify-tag-map', JSON.stringify(map));
         
         showNotification(`Tag "${name}" created`);
         closeCreateTagModal();
@@ -3869,8 +3902,7 @@
       list.innerHTML = '';
       
       try {
-        // Get all tags from localStorage
-        const tags = JSON.parse(localStorage.getItem('calendarify-tags') || '[]');
+        const tags = await fetchTagsFromServer();
         
         // Add tags to the list
         if (tags && tags.length > 0) {
@@ -4049,14 +4081,18 @@
 
     async function removeTag(tagName) {
       try {
-        // Get tags from localStorage
+        const map = JSON.parse(localStorage.getItem('calendarify-tag-map') || '{}');
+        const tagId = map[tagName];
+        if (tagId) {
+          const token = localStorage.getItem('calendarify-token');
+          const clean = token.replace(/^"|"$/g, '');
+          await fetch(`${API_URL}/tags/${tagId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${clean}` } });
+        }
         const tags = JSON.parse(localStorage.getItem('calendarify-tags') || '[]');
-        
-        // Remove the tag
         const updatedTags = tags.filter(tag => tag !== tagName);
-        
-        // Save back to localStorage
+        delete map[tagName];
         localStorage.setItem('calendarify-tags', JSON.stringify(updatedTags));
+        localStorage.setItem('calendarify-tag-map', JSON.stringify(map));
         
         showNotification('Tag removed successfully');
         


### PR DESCRIPTION
## Summary
- add `Workflow` model to Prisma schema and create migration
- persist workflows and event types through Prisma services
- expose CRUD API for workflows
- fetch tags and workflows from server in dashboard
- save workflows to server from editor

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd2fd4b888320865aed8847692281