### PR TITLE
Persist workflows to DB

### DIFF
--- a/backend/src/workflows/workflows.controller.ts
+++ b/backend/src/workflows/workflows.controller.ts
@@ -14,6 +14,12 @@ export class WorkflowsController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get(':id')
+  findOne(@Request() req, @Param('id') id: string) {
+    return this.workflows.findById(req.user.userId, id);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Post()
   create(
     @Request() req,

--- a/backend/src/workflows/workflows.service.ts
+++ b/backend/src/workflows/workflows.service.ts
@@ -7,24 +7,45 @@ export interface Workflow {
   name: string;
   description?: string;
   data?: any;
+  /**
+   * ISO string of last update time used for displaying in the UI
+   */
+  lastEdited?: string;
+  /**
+   * Flattened properties from the data JSON for convenience
+   */
+  trigger?: string;
+  triggerEventTypes?: string[];
+  steps?: any[];
+  status?: boolean;
 }
 
 @Injectable()
 export class WorkflowsService {
   constructor(private prisma: PrismaService) {}
 
+  private format(raw: any): Workflow {
+    const data = raw.data || {};
+    return {
+      id: raw.id,
+      userId: raw.user_id,
+      name: raw.name,
+      description: raw.description || undefined,
+      lastEdited: raw.updated_at ? new Date(raw.updated_at).toISOString() : undefined,
+      trigger: data.trigger,
+      triggerEventTypes: data.triggerEventTypes,
+      steps: data.steps,
+      status: typeof data.status === 'boolean' ? data.status : undefined,
+      data,
+    };
+  }
+
   async list(userId: string) {
     const workflows = await this.prisma.workflow.findMany({
       where: { user_id: userId },
       orderBy: { created_at: 'asc' },
     });
-    return workflows.map(w => ({
-      id: w.id,
-      userId: w.user_id,
-      name: w.name,
-      description: w.description || undefined,
-      data: w.data || undefined,
-    }));
+    return workflows.map(w => this.format(w));
   }
 
   async create(userId: string, data: Pick<Workflow, 'name' | 'description' | 'data'>) {
@@ -36,13 +57,15 @@ export class WorkflowsService {
         data: data.data,
       },
     });
-    return {
-      id: workflow.id,
-      userId: workflow.user_id,
-      name: workflow.name,
-      description: workflow.description || undefined,
-      data: workflow.data || undefined,
-    };
+    return this.format(workflow);
+  }
+
+  async findById(userId: string, workflowId: string): Promise<Workflow | null> {
+    const workflow = await this.prisma.workflow.findFirst({
+      where: { id: workflowId, user_id: userId },
+    });
+    if (!workflow) return null;
+    return this.format(workflow);
   }
 
   async remove(userId: string, workflowId: string) {
@@ -52,7 +75,7 @@ export class WorkflowsService {
   }
 
   async update(userId: string, workflowId: string, data: Partial<Workflow>) {
-    await this.prisma.workflow.updateMany({
+    const updated = await this.prisma.workflow.updateMany({
       where: { id: workflowId, user_id: userId },
       data: {
         name: data.name,
@@ -60,6 +83,8 @@ export class WorkflowsService {
         data: data.data,
       },
     });
-    return this.prisma.workflow.findUnique({ where: { id: workflowId } });
+    if (updated.count === 0) return null;
+    const wf = await this.prisma.workflow.findUnique({ where: { id: workflowId } });
+    return wf ? this.format(wf) : null;
   }
 }

--- a/dashboard/editor/index.html
+++ b/dashboard/editor/index.html
@@ -256,24 +256,27 @@
 
     document.addEventListener('DOMContentLoaded', async () => {
       const id = localStorage.getItem('calendarify-current-workflow');
-      const workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
       if (id) {
-        currentWorkflow = workflows.find(w => w.id === id);
-        if (currentWorkflow && currentWorkflow.trigger) {
-          triggerSelect.value = currentWorkflow.trigger;
-        }
-        if (currentWorkflow && currentWorkflow.name) {
-          nameInput.value = currentWorkflow.name;
-        }
-        if (currentWorkflow && currentWorkflow.steps) {
-          currentWorkflow.steps.forEach(t => canvas.appendChild(createStep(t)));
+        const token = localStorage.getItem('calendarify-token');
+        const clean = token.replace(/^"|"$/g, '');
+        const res = await fetch(`${API_URL}/workflows/${id}`, { headers: { Authorization: `Bearer ${clean}` } });
+        if (res.ok) {
+          currentWorkflow = await res.json();
+          if (currentWorkflow.trigger) {
+            triggerSelect.value = currentWorkflow.trigger;
+          }
+          if (currentWorkflow.name) {
+            nameInput.value = currentWorkflow.name;
+          }
+          if (currentWorkflow.steps) {
+            currentWorkflow.steps.forEach(t => canvas.appendChild(createStep(t)));
+          }
         }
       }
       await renderTriggerProperties();
     });
 
     saveBtn.addEventListener('click', async () => {
-      let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
       const steps = Array.from(canvas.querySelectorAll('.step')).map(s => ({
         type: s.dataset.type,
         props: JSON.parse(s.dataset.props || '{}')
@@ -294,7 +297,6 @@
           headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
           body: JSON.stringify({ name, description: currentWorkflow.description, data: currentWorkflow }),
         });
-        workflows = workflows.map(w => w.id === currentWorkflow.id ? currentWorkflow : w);
       } else {
         const res = await fetch(`${API_URL}/workflows`, {
           method: 'POST',
@@ -302,9 +304,7 @@
           body: JSON.stringify({ name, description: '', data: { trigger, triggerEventTypes, steps, status: true } }),
         });
         currentWorkflow = await res.json();
-        workflows.push(currentWorkflow);
       }
-      localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
       localStorage.removeItem('calendarify-current-workflow');
       localStorage.setItem('calendarify-redirect-to', 'workflows');
       window.location.href = '/dashboard';

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2220,23 +2220,23 @@
       window.location.href = '/dashboard/editor';
     }
 
-    function cloneWorkflow(id) {
-      let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
-      const wf = workflows.find(w => w.id === id);
-      if (!wf) return;
+    async function cloneWorkflow(id) {
       const token = localStorage.getItem('calendarify-token');
       const clean = token.replace(/^"|"$/g, '');
-      fetch(`${API_URL}/workflows`, {
+
+      const existingRes = await fetch(`${API_URL}/workflows/${id}`, { headers: { Authorization: `Bearer ${clean}` } });
+      if (!existingRes.ok) return;
+      const wf = await existingRes.json();
+
+      const res = await fetch(`${API_URL}/workflows`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
         body: JSON.stringify({ name: wf.name + ' Copy', description: wf.description, data: wf.data }),
-      }).then(res => res.json()).then(newWf => {
-        workflows.push(newWf);
-        localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
-        renderWorkflows();
-        renderContacts();
-        showNotification('Workflow cloned');
       });
+      if (res.ok) {
+        showNotification('Workflow cloned');
+        renderWorkflows();
+      }
     }
 
     function deleteWorkflow(id) {
@@ -2245,18 +2245,15 @@
       document.getElementById('delete-workflow-confirm-modal').classList.remove('hidden');
     }
 
-    function confirmDeleteWorkflow() {
+    async function confirmDeleteWorkflow() {
       const workflowId = window.workflowToDelete;
       if (workflowId) {
         const token = localStorage.getItem('calendarify-token');
         const clean = token.replace(/^"|"$/g, '');
-        fetch(`${API_URL}/workflows/${workflowId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${clean}` } });
-        let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
-        workflows = workflows.filter(w => w.id !== workflowId);
-        localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
-        renderWorkflows();
+        await fetch(`${API_URL}/workflows/${workflowId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${clean}` } });
         showNotification('Workflow deleted');
         closeDeleteWorkflowConfirmModal();
+        renderWorkflows();
       }
     }
 
@@ -2312,56 +2309,68 @@
       document.getElementById('event-types-modal').classList.add('hidden');
     }
 
-    function removeEventTypeFromWorkflow(workflowId, eventTypeIndex) {
-      let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
-      const workflow = workflows.find(w => w.id === workflowId);
-      
-      if (workflow && workflow.triggerEventTypes && workflow.triggerEventTypes.length > eventTypeIndex) {
-        // Remove the event type at the specified index
-        workflow.triggerEventTypes.splice(eventTypeIndex, 1);
-        
-        // If no event types left, auto-disable workflow and set to "All Event Types"
-        if (workflow.triggerEventTypes.length === 0) {
-          workflow.triggerEventTypes = [];
-          workflow.status = false; // Disable the workflow
+    async function removeEventTypeFromWorkflow(workflowId, eventTypeIndex) {
+      const token = localStorage.getItem('calendarify-token');
+      const clean = token.replace(/^"|"$/g, '');
+
+      const res = await fetch(`${API_URL}/workflows/${workflowId}`, { headers: { Authorization: `Bearer ${clean}` } });
+      if (!res.ok) return;
+      const workflow = await res.json();
+
+      const wfData = workflow.data || {};
+      wfData.triggerEventTypes = wfData.triggerEventTypes || [];
+
+      if (wfData.triggerEventTypes.length > eventTypeIndex) {
+        wfData.triggerEventTypes.splice(eventTypeIndex, 1);
+
+        if (wfData.triggerEventTypes.length === 0) {
+          wfData.triggerEventTypes = [];
+          wfData.status = false;
           showNotification('Last event type removed. Workflow disabled and set to "All Event Types"');
         } else {
           showNotification('Event type removed from workflow');
         }
-        
-        // Update localStorage
-        localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
-        
-        // Close the modal since there are no more event types to show
-        if (workflow.triggerEventTypes.length === 0) {
+
+        await fetch(`${API_URL}/workflows/${workflowId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+          body: JSON.stringify({ data: wfData }),
+        });
+
+        if (wfData.triggerEventTypes.length === 0) {
           closeEventTypesModal();
         } else {
-          // Refresh the modal with updated event types
-          showEventTypesModal(workflowId, workflow.triggerEventTypes);
+          showEventTypesModal(workflowId, wfData.triggerEventTypes);
         }
-        
-        // Refresh the workflows table
+
         renderWorkflows();
       }
     }
 
-    function toggleWorkflowStatus(id, button) {
-      let workflows = JSON.parse(localStorage.getItem('calendarify-workflows') || '[]');
-      const wf = workflows.find(w => w.id === id);
-      if (wf) {
-        wf.status = !wf.status;
-        localStorage.setItem('calendarify-workflows', JSON.stringify(workflows));
-        
-        // Update button appearance
-        const isActive = wf.status;
-        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-        button.classList.toggle('bg-[#34D399]', isActive);
-        button.classList.toggle('bg-[#19342e]', !isActive);
-        
-        const circle = button.querySelector('div');
-        if (circle) {
-          circle.style.transform = isActive ? 'translateX(20px)' : 'translateX(0)';
-        }
+    async function toggleWorkflowStatus(id, button) {
+      const token = localStorage.getItem('calendarify-token');
+      const clean = token.replace(/^"|"$/g, '');
+
+      const res = await fetch(`${API_URL}/workflows/${id}`, { headers: { Authorization: `Bearer ${clean}` } });
+      if (!res.ok) return;
+      const wf = await res.json();
+
+      const wfData = wf.data || {};
+      wfData.status = !wfData.status;
+
+      await fetch(`${API_URL}/workflows/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+        body: JSON.stringify({ data: wfData }),
+      });
+
+      const isActive = wfData.status;
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      button.classList.toggle('bg-[#34D399]', isActive);
+      button.classList.toggle('bg-[#19342e]', !isActive);
+      const circle = button.querySelector('div');
+      if (circle) {
+        circle.style.transform = isActive ? 'translateX(20px)' : 'translateX(0)';
       }
     }
 


### PR DESCRIPTION
## Summary
- enable retrieving single workflow by ID in the API
- expose a new `/workflows/:id` route
- load workflows from the API instead of localStorage on the editor page
- update workflow actions in dashboard to patch the API
- fix workflow service to return flattened data including trigger, steps, and status

## Testing
- `npm test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687120e4da6883209d771fb06d97046b