### PR TITLE
Add basic video conferencing integrations

### DIFF
--- a/backend/src/integrations/integrations.controller.ts
+++ b/backend/src/integrations/integrations.controller.ts
@@ -1,9 +1,22 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { IntegrationsService } from './integrations.service';
 
 @Controller('integrations')
 export class IntegrationsController {
+  constructor(private readonly integrationsService: IntegrationsService) {}
+
   @Post('google')
   google(@Body() body: any) {
     return { message: 'google integration stub', data: body };
+  }
+
+  @Post('google-meet')
+  googleMeet(@Body() body: any) {
+    return this.integrationsService.connectGoogleMeet(body);
+  }
+
+  @Post('zoom')
+  zoom(@Body() body: any) {
+    return this.integrationsService.connectZoom(body);
   }
 }

--- a/backend/src/integrations/integrations.module.ts
+++ b/backend/src/integrations/integrations.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { IntegrationsController } from './integrations.controller';
+import { IntegrationsService } from './integrations.service';
 
 @Module({
   controllers: [IntegrationsController],
+  providers: [IntegrationsService],
 })
 export class IntegrationsModule {}

--- a/backend/src/integrations/integrations.service.ts
+++ b/backend/src/integrations/integrations.service.ts
@@ -1,4 +1,12 @@
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class IntegrationsService {}
+export class IntegrationsService {
+  connectGoogleMeet(data: any) {
+    return { message: 'google meet integration stub', data };
+  }
+
+  connectZoom(data: any) {
+    return { message: 'zoom integration stub', data };
+  }
+}

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -22,4 +22,20 @@ describe('AppController (e2e)', () => {
       .expect(200)
       .expect('Hello World!');
   });
+
+  it('/api/integrations/google-meet (POST)', () => {
+    return request(app.getHttpServer())
+      .post('/api/integrations/google-meet')
+      .send({ token: 'test' })
+      .expect(201)
+      .expect({ message: 'google meet integration stub', data: { token: 'test' } });
+  });
+
+  it('/api/integrations/zoom (POST)', () => {
+    return request(app.getHttpServer())
+      .post('/api/integrations/zoom')
+      .send({ token: 'test' })
+      .expect(201)
+      .expect({ message: 'zoom integration stub', data: { token: 'test' } });
+  });
 });

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1594,7 +1594,7 @@
                 <div class="text-[#A3B3AF] text-sm">Video</div>
               </div>
             </div>
-            <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
+            <button onclick="openZoomModal()" class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
@@ -1604,7 +1604,7 @@
                 <div class="text-[#A3B3AF] text-sm">Video</div>
               </div>
             </div>
-            <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
+            <button onclick="openGoogleMeetModal()" class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
           </div>
         </div>
       </section>
@@ -4031,6 +4031,56 @@
       document.getElementById('tags-modal').classList.add('hidden');
     }
 
+    function openZoomModal() {
+      document.getElementById('modal-backdrop').classList.remove('hidden');
+      document.getElementById('zoom-modal').classList.remove('hidden');
+    }
+
+    function closeZoomModal() {
+      document.getElementById('modal-backdrop').classList.add('hidden');
+      document.getElementById('zoom-modal').classList.add('hidden');
+    }
+
+    async function activateZoom() {
+      try {
+        const res = await fetch(`${API_URL}/integrations/zoom`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) });
+        if (res.ok) {
+          showNotification('Zoom connected');
+        } else {
+          showNotification('Failed to connect Zoom');
+        }
+      } catch (e) {
+        console.error(e);
+        showNotification('Failed to connect Zoom');
+      }
+      closeZoomModal();
+    }
+
+    function openGoogleMeetModal() {
+      document.getElementById('modal-backdrop').classList.remove('hidden');
+      document.getElementById('google-meet-modal').classList.remove('hidden');
+    }
+
+    function closeGoogleMeetModal() {
+      document.getElementById('modal-backdrop').classList.add('hidden');
+      document.getElementById('google-meet-modal').classList.add('hidden');
+    }
+
+    async function activateGoogleMeet() {
+      try {
+        const res = await fetch(`${API_URL}/integrations/google-meet`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) });
+        if (res.ok) {
+          showNotification('Google Meet connected');
+        } else {
+          showNotification('Failed to connect Google Meet');
+        }
+      } catch (e) {
+        console.error(e);
+        showNotification('Failed to connect Google Meet');
+      }
+      closeGoogleMeetModal();
+    }
+
     async function showContactTagsModal(contactEmail) {
       const modal = document.getElementById('tags-modal');
       const list = document.getElementById('tags-list');
@@ -5551,6 +5601,48 @@
     <div class="flex gap-3">
       <button class="bg-red-500 text-white px-6 py-2 rounded-lg font-bold hover:bg-red-600 transition-colors" onclick="confirmDeleteContact()">Remove</button>
       <button class="text-[#A3B3AF] px-6 py-2 rounded-lg hover:text-white transition-colors" onclick="closeDeleteContactConfirmModal()">Cancel</button>
+    </div>
+  </div>
+
+  <!-- Zoom Activation Modal -->
+  <div id="zoom-modal" class="fixed inset-0 z-50 hidden">
+    <div class="flex items-center justify-center min-h-screen p-4">
+      <div class="bg-[#1E3A34] rounded-xl shadow-2xl w-full max-w-sm">
+        <div class="flex items-center justify-between p-6 border-b border-[#2C4A43]">
+          <h2 class="text-xl font-bold text-white">Connect Zoom</h2>
+          <button onclick="closeZoomModal()" class="text-[#A3B3AF] hover:text-white transition-colors">
+            <span class="material-icons-outlined text-2xl">close</span>
+          </button>
+        </div>
+        <div class="p-6 space-y-4">
+          <p class="text-[#A3B3AF] text-sm">Authorize Calendarify to create Zoom meetings on your behalf.</p>
+        </div>
+        <div class="flex items-center justify-end gap-3 p-6 border-t border-[#2C4A43]">
+          <button onclick="closeZoomModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white transition-colors font-medium">Cancel</button>
+          <button onclick="activateZoom()" class="bg-[#34D399] text-[#1A2E29] px-6 py-3 rounded-lg hover:bg-[#2C4A43] transition-colors font-bold">Connect</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Google Meet Activation Modal -->
+  <div id="google-meet-modal" class="fixed inset-0 z-50 hidden">
+    <div class="flex items-center justify-center min-h-screen p-4">
+      <div class="bg-[#1E3A34] rounded-xl shadow-2xl w-full max-w-sm">
+        <div class="flex items-center justify-between p-6 border-b border-[#2C4A43]">
+          <h2 class="text-xl font-bold text-white">Connect Google Meet</h2>
+          <button onclick="closeGoogleMeetModal()" class="text-[#A3B3AF] hover:text-white transition-colors">
+            <span class="material-icons-outlined text-2xl">close</span>
+          </button>
+        </div>
+        <div class="p-6 space-y-4">
+          <p class="text-[#A3B3AF] text-sm">Authorize Calendarify to create Google Meet meetings on your behalf.</p>
+        </div>
+        <div class="flex items-center justify-end gap-3 p-6 border-t border-[#2C4A43]">
+          <button onclick="closeGoogleMeetModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white transition-colors font-medium">Cancel</button>
+          <button onclick="activateGoogleMeet()" class="bg-[#34D399] text-[#1A2E29] px-6 py-3 rounded-lg hover:bg-[#2C4A43] transition-colors font-bold">Connect</button>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- support Zoom and Google Meet in integrations controller
- expose integration service methods
- add Zoom/Google Meet activation modals in dashboard
- include frontend functions for connecting integrations
- create e2e tests covering new endpoints

## Testing
- `npm test --prefix backend`
- `npm run test:e2e --prefix backend` *(fails: `@prisma/client did not initialize yet`)*


------
https://chatgpt.com/codex/tasks/task_e_6874fa2940d48320a93e3a80d6c074f8