### PR TITLE
Fix Google OAuth redirect

### DIFF
--- a/backend/src/integrations/integrations.controller.ts
+++ b/backend/src/integrations/integrations.controller.ts
@@ -16,8 +16,9 @@ export class IntegrationsController {
   @Get('google/callback')
   async googleCallback(@Query('code') code: string, @Query('state') state: string, @Res() res) {
     await this.integrationsService.handleGoogleCallback(code, state);
-    // Redirect to dashboard with a flag for frontend to show integrations tab and connected state
-    return res.redirect('/dashboard?google_oauth=1');
+    // Redirect back to the frontend dashboard after successful authentication
+    const baseUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+    return res.redirect(`${baseUrl}/dashboard`);
   }
 
   @UseGuards(JwtAuthGuard)


### PR DESCRIPTION
## Summary
- ensure Google OAuth callback redirects to dashboard on frontend

## Testing
- `npm test` *(fails: calendarify@workspace not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6877dbdde03883209878b2c696b02d0b