### PR TITLE
Update integration icons

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1588,7 +1588,7 @@
         <div class="dashboard-grid">
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">videocam</span>
+              <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/zoom.svg" alt="Zoom logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Zoom</div>
                 <div class="text-[#A3B3AF] text-sm">Video</div>
@@ -1598,7 +1598,7 @@
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
+              <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/googlecalendar.svg" alt="Google Calendar logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Google Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync your calendar</div>


### PR DESCRIPTION
## Summary
- replace Zoom and Google Calendar icons with their official logos

## Testing
- `yarn install` *(fails: binaries.prisma.sh blocked)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687a65ad00d4832081be7b84dcef0bc1