### PR TITLE
Remove routing tab and add calendars to integrations

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -64,12 +64,6 @@
           </span>
           Integrations
         </div>
-        <div class="nav-item" data-section="routing" onclick="showSection('routing', this)">
-          <span class="nav-icon"> <!-- routing icon -->
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17 17l4-4m0 0l-4-4m4 4H7a4 4 0 01-4-4V5"/></svg>
-          </span>
-          Routing
-        </div>
       </div>
     </nav>
   </aside>
@@ -613,25 +607,7 @@
                 <div class="text-[#A3B3AF] text-sm">Sync your calendar</div>
               </div>
             </div>
-            <button id="google-calendar-connect-btn" onclick="connectGoogleCalendar()" class="bg-red-500 text-white px-3 py-1 rounded-lg font-bold mt-2" style="font-size: 1rem; font-weight: 600; min-width: 120px;">Connect</button>
-          </div>
-        </div>
-      </section>
-      <!-- Routing Section -->
-      <section id="routing-section" style="display:none;">
-        <div class="flex justify-between items-center mb-6">
-          <h2 class="text-2xl font-bold text-white">Calendar Routing</h2>
-        </div>
-        <div class="dashboard-grid">
-          <div class="card flex flex-col gap-3">
-            <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
-              <div>
-                <div class="text-white font-bold">Google Calendar</div>
-                <div class="text-[#A3B3AF] text-sm">Sync with Google Calendar</div>
-              </div>
-            </div>
-            <button id="google-calendar-connect" onclick="connectGoogleCalendar()" class="bg-red-500 text-white px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
+          <button id="google-calendar-connect-btn" onclick="connectGoogleCalendar()" class="bg-red-500 text-white px-3 py-1 rounded-lg font-bold mt-2" style="font-size: 1rem; font-weight: 600; min-width: 120px;">Connect</button>
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">

--- a/dashboard/index.html.backup
+++ b/dashboard/index.html.backup
@@ -1136,12 +1136,6 @@
           </span>
           Integrations
         </div>
-        <div class="nav-item" data-section="routing" onclick="showSection('routing', this)">
-          <span class="nav-icon"> <!-- routing icon -->
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17 17l4-4m0 0l-4-4m4 4H7a4 4 0 01-4-4V5"/></svg>
-          </span>
-          Routing
-        </div>
       </div>
     </nav>
   </aside>
@@ -1683,24 +1677,6 @@
               <div>
                 <div class="text-white font-bold">Google Meet</div>
                 <div class="text-[#A3B3AF] text-sm">Video</div>
-              </div>
-            </div>
-            <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
-          </div>
-        </div>
-      </section>
-      <!-- Routing Section -->
-      <section id="routing-section" style="display:none;">
-        <div class="flex justify-between items-center mb-6">
-          <h2 class="text-2xl font-bold text-white">Calendar Routing</h2>
-        </div>
-        <div class="dashboard-grid">
-          <div class="card flex flex-col gap-3">
-            <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
-              <div>
-                <div class="text-white font-bold">Google Calendar</div>
-                <div class="text-[#A3B3AF] text-sm">Sync with Google Calendar</div>
               </div>
             </div>
             <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>


### PR DESCRIPTION
## Summary
- remove routing tab on the dashboard
- move Outlook and Apple calendar integrations into the Integrations tab

## Testing
- `yarn test` *(fails: ts-jest missing peer dependency)*

------
https://chatgpt.com/codex/tasks/task_e_687b8210a0088320ab01223fb0fbdeea