### PR TITLE
Remove routing tab and add calendars to integrations

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -20,6 +20,8 @@
         });
         updateGoogleCalendarButton();
         updateZoomButton();
+        updateOutlookCalendarButton();
+        updateAppleCalendarButton();
       }
     }
 
@@ -145,6 +147,8 @@
         setTimeout(() => {
           updateGoogleCalendarButton();
           updateZoomButton();
+          updateOutlookCalendarButton();
+          updateAppleCalendarButton();
         }, 100); // Wait for tab to show
       }
     }
@@ -3272,6 +3276,53 @@
     window.openDisconnectZoomModal = openDisconnectZoomModal;
     window.closeDisconnectZoomModal = closeDisconnectZoomModal;
     window.confirmDisconnectZoom = confirmDisconnectZoom;
+
+    function updateOutlookCalendarButton() {
+      const btn = document.getElementById('outlook-calendar-connect-btn');
+      if (!btn) return;
+      const connected = localStorage.getItem('calendarify-outlook-calendar-connected') === 'true';
+      if (connected) {
+        btn.textContent = 'Connected';
+        btn.style.backgroundColor = '#34D399';
+        btn.style.color = '#1A2E29';
+      } else {
+        btn.textContent = 'Not Connected';
+        btn.style.backgroundColor = '#ef4444';
+        btn.style.color = '#fff';
+      }
+    }
+    window.updateOutlookCalendarButton = updateOutlookCalendarButton;
+
+    function toggleOutlookCalendar() {
+      const connected = localStorage.getItem('calendarify-outlook-calendar-connected') === 'true';
+      localStorage.setItem('calendarify-outlook-calendar-connected', (!connected).toString());
+      updateOutlookCalendarButton();
+    }
+    window.toggleOutlookCalendar = toggleOutlookCalendar;
+
+    function updateAppleCalendarButton() {
+      const btn = document.getElementById('apple-calendar-connect-btn');
+      if (!btn) return;
+      const connected = localStorage.getItem('calendarify-apple-calendar-connected') === 'true';
+      if (connected) {
+        btn.textContent = 'Connected';
+        btn.style.backgroundColor = '#34D399';
+        btn.style.color = '#1A2E29';
+      } else {
+        btn.textContent = 'Not Connected';
+        btn.style.backgroundColor = '#ef4444';
+        btn.style.color = '#fff';
+      }
+    }
+    window.updateAppleCalendarButton = updateAppleCalendarButton;
+
+    function toggleAppleCalendar() {
+      const connected = localStorage.getItem('calendarify-apple-calendar-connected') === 'true';
+      localStorage.setItem('calendarify-apple-calendar-connected', (!connected).toString());
+      updateAppleCalendarButton();
+    }
+    window.toggleAppleCalendar = toggleAppleCalendar;
+
     localStorage.setItem('calendarify-tags', JSON.stringify(['Client', 'VIP']));
     if (!localStorage.getItem('calendarify-contacts')) {
       localStorage.setItem('calendarify-contacts', JSON.stringify([

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -64,12 +64,6 @@
           </span>
           Integrations
         </div>
-        <div class="nav-item" data-section="routing" onclick="showSection('routing', this)">
-          <span class="nav-icon"> <!-- routing icon -->
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17 17l4-4m0 0l-4-4m4 4H7a4 4 0 01-4-4V5"/></svg>
-          </span>
-          Routing
-        </div>
       </div>
     </nav>
   </aside>
@@ -597,7 +591,7 @@
         <div class="dashboard-grid">
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/zoom.svg" alt="Zoom logo" class="w-6 h-6">
+              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/zoom.svg" alt="Zoom logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Zoom</div>
                 <div class="text-[#A3B3AF] text-sm">Video</div>
@@ -607,7 +601,7 @@
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/googlecalendar.svg" alt="Google Calendar logo" class="w-6 h-6">
+              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/google_calendar.svg" alt="Google Calendar logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Google Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync your calendar</div>
@@ -615,43 +609,25 @@
             </div>
             <button id="google-calendar-connect-btn" onclick="connectGoogleCalendar()" class="bg-red-500 text-white px-3 py-1 rounded-lg font-bold mt-2" style="font-size: 1rem; font-weight: 600; min-width: 120px;">Connect</button>
           </div>
-        </div>
-      </section>
-      <!-- Routing Section -->
-      <section id="routing-section" style="display:none;">
-        <div class="flex justify-between items-center mb-6">
-          <h2 class="text-2xl font-bold text-white">Calendar Routing</h2>
-        </div>
-        <div class="dashboard-grid">
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
-              <div>
-                <div class="text-white font-bold">Google Calendar</div>
-                <div class="text-[#A3B3AF] text-sm">Sync with Google Calendar</div>
-              </div>
-            </div>
-            <button id="google-calendar-connect" onclick="connectGoogleCalendar()" class="bg-red-500 text-white px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
-          </div>
-          <div class="card flex flex-col gap-3">
-            <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
+              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/outlook.svg" alt="Outlook logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Outlook Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync with Outlook</div>
               </div>
             </div>
-            <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
+            <button id="outlook-calendar-connect-btn" onclick="toggleOutlookCalendar()" class="px-3 py-1 rounded-lg font-bold mt-2" style="font-size: 1rem; font-weight: 600; min-width: 120px; background-color:#ef4444; color:#fff;">Not Connected</button>
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
+              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/apple.svg" alt="Apple Calendar logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Apple Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync with iCloud</div>
               </div>
             </div>
-            <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
+            <button id="apple-calendar-connect-btn" onclick="toggleAppleCalendar()" class="px-3 py-1 rounded-lg font-bold mt-2" style="font-size: 1rem; font-weight: 600; min-width: 120px; background-color:#ef4444; color:#fff;">Not Connected</button>
           </div>
         </div>
       </section>

--- a/dashboard/index.html.backup
+++ b/dashboard/index.html.backup
@@ -1136,12 +1136,6 @@
           </span>
           Integrations
         </div>
-        <div class="nav-item" data-section="routing" onclick="showSection('routing', this)">
-          <span class="nav-icon"> <!-- routing icon -->
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17 17l4-4m0 0l-4-4m4 4H7a4 4 0 01-4-4V5"/></svg>
-          </span>
-          Routing
-        </div>
       </div>
     </nav>
   </aside>
@@ -1669,7 +1663,7 @@
         <div class="dashboard-grid">
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">videocam</span>
+              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/zoom.svg" alt="Zoom logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Zoom</div>
                 <div class="text-[#A3B3AF] text-sm">Video</div>
@@ -1679,35 +1673,17 @@
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">videocam</span>
-              <div>
-                <div class="text-white font-bold">Google Meet</div>
-                <div class="text-[#A3B3AF] text-sm">Video</div>
-              </div>
-            </div>
-            <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
-          </div>
-        </div>
-      </section>
-      <!-- Routing Section -->
-      <section id="routing-section" style="display:none;">
-        <div class="flex justify-between items-center mb-6">
-          <h2 class="text-2xl font-bold text-white">Calendar Routing</h2>
-        </div>
-        <div class="dashboard-grid">
-          <div class="card flex flex-col gap-3">
-            <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
+              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/google_calendar.svg" alt="Google Calendar logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Google Calendar</div>
-                <div class="text-[#A3B3AF] text-sm">Sync with Google Calendar</div>
+                <div class="text-[#A3B3AF] text-sm">Sync your calendar</div>
               </div>
             </div>
             <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold mt-2">Connect</button>
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
+              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/outlook.svg" alt="Outlook logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Outlook Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync with Outlook</div>
@@ -1717,7 +1693,7 @@
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <span class="material-icons-outlined text-2xl text-[#34D399]">event</span>
+              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/apple.svg" alt="Apple Calendar logo" class="w-6 h-6">
               <div>
                 <div class="text-white font-bold">Apple Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync with iCloud</div>


### PR DESCRIPTION
## Summary
- remove routing tab on the dashboard
- move Outlook and Apple calendar integrations into the Integrations tab
- match connection buttons with Google and Zoom
- show the official color logos on all integration cards

## Testing
- `yarn test` *(fails: ts-jest missing peer dependency)*

------
https://chatgpt.com/codex/tasks/task_e_687b8210a0088320ab01223fb0fbdeea