### PR TITLE
Remove backgrounds from integrations icons

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -591,7 +591,7 @@
         <div class="dashboard-grid">
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/zoom.svg" alt="Zoom logo" class="w-6 h-6">
+                <svg xmlns="http://www.w3.org/2000/svg" aria-label="Zoom" role="img" viewBox="0 0 512 512" width="24" height="24"><path fill="#fff" d="M428 357c8 2 15-2 19-8 2-3 2-8 2-19V179c0-11 0-15-2-19-3-8-11-11-19-8-21 14-67 55-68 72-.8 3-.8 8-.8 15v38c0 8 0 11 .8 15 1 8 4 15 8 19 12 9 52 45 61 45zM64 187c0-15 0-23 3-27 2-4 8-8 11-11 4-3 11-3 27-3h129c38 0 57 0 72 8 11 8 23 15 30 30 8 15 8 34 8 72v68c0 15 0 23-3 27-2 4-8 8-11 11-4 3-11 3-27 3H174c-38 0-57 0-72-8-11-8-23-15-30-30-8-15-8-34-8-72z"/></svg>
               <div>
                 <div class="text-white font-bold">Zoom</div>
                 <div class="text-[#A3B3AF] text-sm">Video</div>
@@ -601,7 +601,7 @@
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/google_calendar.svg" alt="Google Calendar logo" class="w-6 h-6">
+                <svg xmlns="http://www.w3.org/2000/svg" aria-label="Google Calendar" role="img" viewBox="0 0 512 512" width="24" height="24"><path d="M100 135q0-35 37-35H340v74H174V340H100" fill="#4285f4"/><path d="m338 100v76h74v-41q0-35-35-35" fill="#1967d2"/><path d="m100 338v39q0 35 35 35h41v-74" fill="#188038"/><path d="M348 338H174v74H338" fill="#34a853"/><path d="m338 339V174h74V338" fill="#fbbc04"/><path d="M338 412v-74h74" fill="#ea4335"/><path d="m204 229a25 22 1 1125 27h-9 9a25 22 1 11-25 27m66-52 27-19h4v96" stroke="#4285f4" stroke-width="15" fill="none"/></svg>
               <div>
                 <div class="text-white font-bold">Google Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync your calendar</div>
@@ -611,7 +611,7 @@
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/outlook.svg" alt="Outlook logo" class="w-6 h-6">
+                <svg xmlns="http://www.w3.org/2000/svg" aria-label="Outlook" role="img" viewBox="0 0 512 512" width="24" height="24"><rect width="231" height="270" x="168" y="107" fill="#05a" rx="3%"/><path fill="#136" d="M398 247v23l15-8s0-7-5-9l-10-6zm-230 43v70h77v-70h-77z"/><path fill="#17d" d="M168 150v70h77v-70h-77zm77 70v70h77v-70h-77zm77 70v70h77v-70h-77z"/><path fill="#3ae" d="M245 150v70h77v-70h-77zm77 70v70h77v-70h-77z"/><path fill="#5cf" d="M322 150h77v70h-77z"/><path fill="#19e" d="M413 261 282 336s121 73 124 71c5-3 7-11 7-18V261Z"/><path fill="#2ae" d="M160 266c-4 3-6 7-6 12v117c0 8 6 14 14 14h230c4 0 5 0 8-2"/><rect width="172" height="172" x="70" y="172" fill="#18e" rx="3%"/><path fill="#fff" d="M155 230c14 0 22 11 22 29s-9 28-23 28c-11 0-22-10-22-28 0-15 7-29 23-29Zm-1 75c26 0 44-18 44-47 0-25-16-46-43-46-28 0-44 20-44 48 0 27 20 45 43 45Z"/></svg>
               <div>
                 <div class="text-white font-bold">Outlook Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync with Outlook</div>
@@ -621,7 +621,7 @@
           </div>
           <div class="card flex flex-col gap-3">
             <div class="flex items-center gap-3">
-              <img src="https://raw.githubusercontent.com/edent/SuperTinyIcons/master/images/svg/apple.svg" alt="Apple Calendar logo" class="w-6 h-6">
+                <svg xmlns="http://www.w3.org/2000/svg" aria-label="Apple" role="img" viewBox="0 0 512 512" width="24" height="24"><path d="m406 335s-9 30-26 54-31 47-60 47c-23 0-35-15-61-15s-42 15-64 15-33-15-50-35c-44-55-62-146-38-194s59-58 84-58 48 16 63 16 38-17 68-17 59 13 74 38c-49 27-64 115 10 149M327 56c5 36-27 89-76 88-5-42 32-85 76-88" fill="#fff"/></svg>
               <div>
                 <div class="text-white font-bold">Apple Calendar</div>
                 <div class="text-[#A3B3AF] text-sm">Sync with iCloud</div>


### PR DESCRIPTION
## Summary
- inline the integration card icons with transparent backgrounds

## Testing
- `yarn install` *(fails: binaries.prisma.sh blocked)*
- `yarn test` *(fails: missing peer deps)*

------
https://chatgpt.com/codex/tasks/task_e_687b98dfe7348320868f602dba7dfdaf