### PR TITLE
Add Apple Calendar CalDAV integration

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -65,6 +65,7 @@ model ExternalCalendar {
   external_id   String
   access_token  String?
   refresh_token String?
+  password      String?
 }
 
 model Booking {

--- a/backend/src/integrations/integrations.controller.ts
+++ b/backend/src/integrations/integrations.controller.ts
@@ -65,6 +65,27 @@ export class IntegrationsController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Post('apple/connect')
+  async connectApple(@Req() req, @Body() body: { email: string; password: string }) {
+    await this.integrationsService.connectAppleCalendar(req.user.userId, body.email, body.password);
+    return { message: 'Apple Calendar connected' };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('apple/status')
+  async appleStatus(@Req() req) {
+    const connected = await this.integrationsService.isAppleConnected(req.user.userId);
+    return { connected };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('apple/disconnect')
+  async disconnectApple(@Req() req) {
+    await this.integrationsService.disconnectAppleCalendar(req.user.userId);
+    return { message: 'Apple Calendar disconnected' };
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Delete('google/disconnect')
   async disconnectGoogle(@Req() req) {
     await this.integrationsService.disconnectGoogle(req.user.userId);

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -3303,25 +3303,103 @@
     function updateAppleCalendarButton() {
       const btn = document.getElementById('apple-calendar-connect-btn');
       if (!btn) return;
-      const connected = localStorage.getItem('calendarify-apple-calendar-connected') === 'true';
-      if (connected) {
-        btn.textContent = 'Connected';
-        btn.style.backgroundColor = '#34D399';
-        btn.style.color = '#1A2E29';
-      } else {
+      const token = localStorage.getItem('calendarify-token');
+      if (!token) {
         btn.textContent = 'Not Connected';
         btn.style.backgroundColor = '#ef4444';
         btn.style.color = '#fff';
+        btn.onclick = connectAppleCalendar;
+        return;
       }
+      const clean = token.replace(/^\"|\"$/g, '');
+      fetch(`${API_URL}/integrations/apple/status`, { headers: { Authorization: `Bearer ${clean}` } })
+        .then(res => res.json())
+        .then(data => {
+          if (data.connected) {
+            btn.textContent = 'Connected';
+            btn.style.backgroundColor = '#34D399';
+            btn.style.color = '#1A2E29';
+            btn.onclick = openDisconnectAppleModal;
+          } else {
+            btn.textContent = 'Not Connected';
+            btn.style.backgroundColor = '#ef4444';
+            btn.style.color = '#fff';
+            btn.onclick = connectAppleCalendar;
+          }
+        })
+        .catch(() => {
+          btn.textContent = 'Not Connected';
+          btn.style.backgroundColor = '#ef4444';
+          btn.style.color = '#fff';
+          btn.onclick = connectAppleCalendar;
+        });
     }
     window.updateAppleCalendarButton = updateAppleCalendarButton;
 
-    function toggleAppleCalendar() {
-      const connected = localStorage.getItem('calendarify-apple-calendar-connected') === 'true';
-      localStorage.setItem('calendarify-apple-calendar-connected', (!connected).toString());
-      updateAppleCalendarButton();
+    function connectAppleCalendar() {
+      document.getElementById('modal-backdrop').classList.remove('hidden');
+      document.getElementById('connect-apple-modal').classList.remove('hidden');
     }
-    window.toggleAppleCalendar = toggleAppleCalendar;
+    window.connectAppleCalendar = connectAppleCalendar;
+
+    function closeConnectAppleModal() {
+      document.getElementById('modal-backdrop').classList.add('hidden');
+      document.getElementById('connect-apple-modal').classList.add('hidden');
+    }
+    window.closeConnectAppleModal = closeConnectAppleModal;
+
+    async function submitAppleConnect() {
+      const email = document.getElementById('apple-email').value.trim();
+      const password = document.getElementById('apple-password').value.trim();
+      if (!email || !password) {
+        showNotification('Email and password required');
+        return;
+      }
+      const token = localStorage.getItem('calendarify-token');
+      if (!token) return;
+      const clean = token.replace(/^\"|\"$/g, '');
+      const res = await fetch(`${API_URL}/integrations/apple/connect`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+        body: JSON.stringify({ email, password }),
+      });
+      if (res.ok) {
+        showNotification('Apple Calendar connected');
+        updateAppleCalendarButton();
+        closeConnectAppleModal();
+      } else {
+        showNotification('Failed to connect Apple Calendar');
+      }
+    }
+    window.submitAppleConnect = submitAppleConnect;
+
+    function openDisconnectAppleModal() {
+      document.getElementById('modal-backdrop').classList.remove('hidden');
+      document.getElementById('disconnect-apple-modal').classList.remove('hidden');
+    }
+    function closeDisconnectAppleModal() {
+      document.getElementById('modal-backdrop').classList.add('hidden');
+      document.getElementById('disconnect-apple-modal').classList.add('hidden');
+    }
+    async function confirmDisconnectApple() {
+      const token = localStorage.getItem('calendarify-token');
+      if (!token) return;
+      const clean = token.replace(/^\"|\"$/g, '');
+      const res = await fetch(`${API_URL}/integrations/apple/disconnect`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${clean}` },
+      });
+      if (res.ok) {
+        showNotification('Apple Calendar disconnected');
+        updateAppleCalendarButton();
+      } else {
+        showNotification('Failed to disconnect Apple Calendar');
+      }
+      closeDisconnectAppleModal();
+    }
+    window.openDisconnectAppleModal = openDisconnectAppleModal;
+    window.closeDisconnectAppleModal = closeDisconnectAppleModal;
+    window.confirmDisconnectApple = confirmDisconnectApple;
 
     localStorage.setItem('calendarify-tags', JSON.stringify(['Client', 'VIP']));
     if (!localStorage.getItem('calendarify-contacts')) {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -627,7 +627,7 @@
                 <div class="text-[#A3B3AF] text-sm">Sync with iCloud</div>
               </div>
             </div>
-            <button id="apple-calendar-connect-btn" onclick="toggleAppleCalendar()" class="px-3 py-1 rounded-lg font-bold mt-2" style="font-size: 1rem; font-weight: 600; min-width: 120px; background-color:#ef4444; color:#fff;">Not Connected</button>
+            <button id="apple-calendar-connect-btn" onclick="connectAppleCalendar()" class="px-3 py-1 rounded-lg font-bold mt-2" style="font-size: 1rem; font-weight: 600; min-width: 120px; background-color:#ef4444; color:#fff;">Not Connected</button>
           </div>
         </div>
       </section>
@@ -851,6 +851,56 @@
         <div class="flex items-center justify-end gap-3 p-6 border-t border-[#2C4A43]">
           <button onclick="closeDisconnectZoomModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white transition-colors font-medium">Cancel</button>
           <button onclick="confirmDisconnectZoom()" class="bg-red-500 text-white px-6 py-3 rounded-lg hover:bg-red-600 transition-colors font-bold">Disconnect</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Connect Apple Calendar Modal -->
+  <div id="connect-apple-modal" class="fixed inset-0 z-50 hidden">
+    <div class="flex items-center justify-center min-h-screen p-4">
+      <div class="bg-[#1E3A34] rounded-xl shadow-2xl w-full max-w-md">
+        <div class="flex items-center justify-between p-6 border-b border-[#2C4A43]">
+          <h2 class="text-xl font-bold text-white">Connect Apple Calendar</h2>
+          <button onclick="closeConnectAppleModal()" class="text-[#A3B3AF] hover:text-white transition-colors">
+            <span class="material-icons-outlined text-2xl">close</span>
+          </button>
+        </div>
+        <form onsubmit="submitAppleConnect(); return false;" class="p-6 space-y-4">
+          <p class="text-[#A3B3AF] text-sm">To create an app-specific password:</p>
+          <ol class="list-decimal list-inside text-[#A3B3AF] text-sm space-y-1">
+            <li>Visit <a href="https://appleid.apple.com" target="_blank" class="text-[#34D399] underline">appleid.apple.com</a> and sign in.</li>
+            <li>Under <span class="text-white">Security</span> choose <span class="text-white">App-Specific Passwords</span> &gt; <span class="text-white">Generate Password…</span></li>
+            <li>Copy the generated password and paste it below.</li>
+          </ol>
+          <p class="text-[#A3B3AF] text-sm">We store this password in our database so Calendarify can sync your events. Do not reuse it elsewhere.</p>
+          <input type="email" id="apple-email" placeholder="Apple ID email" class="w-full bg-[#19342e] border border-[#2C4A43] text-[#E0E0E0] rounded-lg px-4 py-3 focus:border-[#34D399] focus:ring-2 focus:ring-[#34D399]" />
+          <input type="password" id="apple-password" placeholder="App-specific password" class="w-full bg-[#19342e] border border-[#2C4A43] text-[#E0E0E0] rounded-lg px-4 py-3 focus:border-[#34D399] focus:ring-2 focus:ring-[#34D399]" />
+          <div class="flex items-center justify-end gap-3 pt-4 border-t border-[#2C4A43]">
+            <button type="button" onclick="closeConnectAppleModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white transition-colors font-medium">Cancel</button>
+            <button type="submit" class="bg-[#34D399] text-[#1A2E29] px-6 py-3 rounded-lg hover:bg-[#2fb67c] transition-colors font-bold">Connect</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Disconnect Apple Calendar Modal -->
+  <div id="disconnect-apple-modal" class="fixed inset-0 z-50 hidden">
+    <div class="flex items-center justify-center min-h-screen p-4">
+      <div class="bg-[#1E3A34] rounded-xl shadow-2xl w-full max-w-sm">
+        <div class="flex items-center justify-between p-6 border-b border-[#2C4A43]">
+          <h2 class="text-xl font-bold text-white">Disconnect Apple Calendar</h2>
+          <button onclick="closeDisconnectAppleModal()" class="text-[#A3B3AF] hover:text-white transition-colors">
+            <span class="material-icons-outlined text-2xl">close</span>
+          </button>
+        </div>
+        <div class="p-6 space-y-4">
+          <p class="text-[#A3B3AF] text-sm">Are you sure you want to disconnect Apple Calendar? This will remove the saved password.</p>
+        </div>
+        <div class="flex items-center justify-end gap-3 p-6 border-t border-[#2C4A43]">
+          <button onclick="closeDisconnectAppleModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white transition-colors font-medium">Cancel</button>
+          <button onclick="confirmDisconnectApple()" class="bg-red-500 text-white px-6 py-3 rounded-lg hover:bg-red-600 transition-colors font-bold">Disconnect</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- extend `ExternalCalendar` schema with `password` field
- implement Apple Calendar CalDAV support on the backend
- expose new `/integrations/apple/*` API routes
- provide Apple Calendar connection modal and logic in dashboard
- guide users to create an app-specific iCloud password and inform them it will be stored
- fix HTML structure for the Apple connection modal

## Testing
- `npm test --silent` *(fails: lockfile missing)*
- `npx prisma generate` *(fails to download Prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_687cc9cf8594832084cb9b1e5bfd51ba