### PR TITLE
Fix env sync for local DB setup

### DIFF
--- a/backend/scripts/seed_admin.js
+++ b/backend/scripts/seed_admin.js
@@ -1,0 +1,26 @@
+const { PrismaClient } = require('@prisma/client');
+const bcrypt = require('bcrypt');
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = 'admin@admin.com';
+  const name = 'admin';
+  const password = 'admin';
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (!existing) {
+    const hashed = await bcrypt.hash(password, 10);
+    await prisma.user.create({ data: { email, name, password: hashed } });
+    console.log('Created default admin user');
+  } else {
+    console.log('Default admin user already exists');
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/run_local.py
+++ b/run_local.py
@@ -129,6 +129,29 @@ def ensure_backend_env():
         print('Copied .env to backend/.env')
 
 
+def update_database_url(env_path):
+    """Replace default postgres credentials with current user and reload env."""
+    if not os.path.exists(env_path):
+        return
+
+    with open(env_path, 'r') as f:
+        content = f.read()
+
+    import getpass
+    current_user = getpass.getuser()
+    new_content = content.replace('postgres:postgres@', f'{current_user}@')
+
+    if new_content != content:
+        with open(env_path, 'w') as f:
+            f.write(new_content)
+        print(f'Updated DATABASE_URL in {env_path} to use user: {current_user}')
+
+    for line in new_content.splitlines():
+        if line.startswith('DATABASE_URL='):
+            os.environ['DATABASE_URL'] = line.split('=', 1)[1]
+            break
+
+
 def load_env_files():
     """Load environment variables from .env files"""
     for env_path in ['.env', 'backend/.env']:
@@ -176,21 +199,6 @@ def check_apple_calendar():
 def setup_database():
     os.chdir('backend')
     
-    # Update DATABASE_URL to use current user instead of 'postgres'
-    env_file = '.env'
-    if os.path.exists(env_file):
-        with open(env_file, 'r') as f:
-            content = f.read()
-        
-        # Replace postgres user with current user
-        import getpass
-        current_user = getpass.getuser()
-        content = content.replace('postgres:postgres@', f'{current_user}@')
-        
-        with open(env_file, 'w') as f:
-            f.write(content)
-        print(f'Updated DATABASE_URL to use user: {current_user}')
-    
     # Try to create database if it doesn't exist
     try:
         run('createdb calendarify')
@@ -200,7 +208,7 @@ def setup_database():
     
     # Try to push schema
     try:
-        run('npx prisma db push')
+        run('npx prisma db push', env=os.environ.copy())
         print('Database schema updated successfully')
     except SystemExit as e:
         print(f'Failed to push schema: {e}')
@@ -208,13 +216,22 @@ def setup_database():
         try:
             run('dropdb calendarify --if-exists')
             run('createdb calendarify')
-            run('npx prisma db push')
+            run('npx prisma db push', env=os.environ.copy())
             print('Database schema updated successfully (retry)')
         except SystemExit:
             print('❌ Database setup failed. Please check PostgreSQL configuration.')
             sys.exit(1)
     
     os.chdir('..')
+
+
+def seed_default_admin():
+    """Ensure a default admin user exists for local login."""
+    script_path = os.path.join('backend', 'scripts', 'seed_admin.js')
+    if os.path.exists(script_path):
+        run(f'node {script_path}', env=os.environ.copy())
+    else:
+        print('Seed script not found, skipping admin user seeding')
 
 
 def start_backend():
@@ -243,10 +260,18 @@ def serve_frontend():
     # Use the Node server that comes with the project to serve the static files
     # with extensionless URL support.
     def _run():
-        # Make sure we're in the project root directory
-        os.chdir('/Users/heinebautz/portfolio-github/Calendarify')
+        # Run from the repository root regardless of the caller's cwd
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+        # Ensure the frontend runs on its own port to avoid conflicts with the
+        # backend (which uses PORT from the .env file).
+        env = os.environ.copy()
+        # Force the frontend to run on port 3000 regardless of the PORT value
+        # from .env which is used by the backend.
+        env['PORT'] = '3000'
+
         # Use the custom server.js that handles clean URLs
-        run('node server.js')
+        run('node server.js', env=env)
     t = Thread(target=_run)
     t.daemon = True
     t.start()
@@ -269,6 +294,8 @@ def main():
     ensure_env_file('.')
     ensure_env_file('backend')
     ensure_backend_env()
+    update_database_url('.env')
+    update_database_url('backend/.env')
     load_env_files()
     check_apple_calendar()
     run('npm install')
@@ -290,6 +317,7 @@ def main():
         print("\n✓ All required services are available locally")
 
     setup_database()
+    seed_default_admin()
     start_backend()
     serve_frontend()
     print("\nOpening http://localhost:3000/log-in in your browser...")


### PR DESCRIPTION
## Summary
- update `.env` files using new `update_database_url` helper
- ensure Prisma CLI picks up the modified `DATABASE_URL`
- run frontend server on its own port
- force frontend port to 3000 so it doesn't clash with backend
- seed default admin user for easier local login

## Testing
- `npm test` *(fails: package not in lockfile)*
- `python3 run_local.py` *(fails: Node.js 20.x not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6880ef5592d88320b158a9168f019778