### PR TITLE
Fix Apple calendar credential check

### DIFF
--- a/backend/src/integrations/integrations.service.ts
+++ b/backend/src/integrations/integrations.service.ts
@@ -271,11 +271,12 @@ export class IntegrationsService {
         headers: {
           Depth: '0',
           Authorization: 'Basic ' + Buffer.from(`${email}:${password}`).toString('base64'),
+          'Content-Type': 'application/xml',
         },
         body: `<?xml version="1.0" encoding="UTF-8"?>\n<propfind xmlns="DAV:">\n  <prop><current-user-principal/></prop>\n</propfind>`,
       });
       if (res.status === 207) return 'ok';
-      if (res.status === 401) return 'invalid';
+      if (res.status === 401 || res.status === 403) return 'invalid';
       return 'unreachable';
     } catch {
       return 'unreachable';


### PR DESCRIPTION
## Summary
- set `Content-Type` header when verifying Apple Calendar credentials
- treat 403 responses as invalid credentials

## Testing
- `yarn test` *(fails: ts-jest peer dependency issue)*

------
https://chatgpt.com/codex/tasks/task_e_688104d170f88320b05a7fccc74375a4