### PR TITLE
Fix Apple calendar credential check

### DIFF
--- a/backend/src/integrations/integrations.service.spec.ts
+++ b/backend/src/integrations/integrations.service.spec.ts
@@ -29,9 +29,11 @@ describe('IntegrationsService - Apple Calendar', () => {
   });
 
   it('throws BadRequestException for invalid credentials', async () => {
-    (global as any).fetch = jest.fn().mockResolvedValue({ status: 401 });
-    await expect(
-      service.connectAppleCalendar('user1', 'bad@example.com', 'bad')
-    ).rejects.toBeInstanceOf(BadRequestException);
+    for (const status of [401, 403, 404]) {
+      (global as any).fetch = jest.fn().mockResolvedValue({ status });
+      await expect(
+        service.connectAppleCalendar('user1', 'bad@example.com', 'bad')
+      ).rejects.toBeInstanceOf(BadRequestException);
+    }
   });
 });

--- a/backend/src/integrations/integrations.service.ts
+++ b/backend/src/integrations/integrations.service.ts
@@ -271,11 +271,14 @@ export class IntegrationsService {
         headers: {
           Depth: '0',
           Authorization: 'Basic ' + Buffer.from(`${email}:${password}`).toString('base64'),
+          'Content-Type': 'application/xml',
+          'User-Agent': 'calendarify-caldav',
+          Accept: 'application/xml,text/xml;q=0.9,*/*;q=0.8',
         },
         body: `<?xml version="1.0" encoding="UTF-8"?>\n<propfind xmlns="DAV:">\n  <prop><current-user-principal/></prop>\n</propfind>`,
       });
       if (res.status === 207) return 'ok';
-      if (res.status === 401) return 'invalid';
+      if (res.status === 401 || res.status === 403 || res.status === 404) return 'invalid';
       return 'unreachable';
     } catch {
       return 'unreachable';


### PR DESCRIPTION
## Summary
- set `User-Agent` and `Accept` headers when verifying Apple Calendar credentials
- treat 404 responses as invalid credentials
- test invalid Apple credentials for 401/403/404 statuses

## Testing
- `yarn test` *(fails: ts-jest peer dependency issue)*

------
https://chatgpt.com/codex/tasks/task_e_688104d170f88320b05a7fccc74375a4