### PR TITLE
Fix Apple calendar credential check

### DIFF
--- a/backend/src/integrations/integrations.service.spec.ts
+++ b/backend/src/integrations/integrations.service.spec.ts
@@ -29,9 +29,11 @@ describe('IntegrationsService - Apple Calendar', () => {
   });
 
   it('throws BadRequestException for invalid credentials', async () => {
-    (global as any).fetch = jest.fn().mockResolvedValue({ status: 401 });
-    await expect(
-      service.connectAppleCalendar('user1', 'bad@example.com', 'bad')
-    ).rejects.toBeInstanceOf(BadRequestException);
+    for (const status of [401, 403, 404]) {
+      (global as any).fetch = jest.fn().mockResolvedValue({ status });
+      await expect(
+        service.connectAppleCalendar('user1', 'bad@example.com', 'bad')
+      ).rejects.toBeInstanceOf(BadRequestException);
+    }
   });
 });

--- a/backend/src/integrations/integrations.service.ts
+++ b/backend/src/integrations/integrations.service.ts
@@ -266,24 +266,43 @@ export class IntegrationsService {
 
   private async verifyAppleCredentials(email: string, password: string): Promise<'ok' | 'invalid' | 'unreachable'> {
     try {
+      // DEBUG PRINT - remove when Apple integration is stable
+      console.log('[DEBUG] verifyAppleCredentials request for', email);
       const res = await fetch('https://caldav.icloud.com/', {
         method: 'PROPFIND',
         headers: {
           Depth: '0',
           Authorization: 'Basic ' + Buffer.from(`${email}:${password}`).toString('base64'),
+          'Content-Type': 'application/xml',
+          'User-Agent': 'calendarify-caldav',
+          Accept: 'application/xml,text/xml;q=0.9,*/*;q=0.8',
         },
         body: `<?xml version="1.0" encoding="UTF-8"?>\n<propfind xmlns="DAV:">\n  <prop><current-user-principal/></prop>\n</propfind>`,
       });
+      // DEBUG PRINT - show status returned by Apple
+      console.log('[DEBUG] verifyAppleCredentials response status:', res.status);
       if (res.status === 207) return 'ok';
-      if (res.status === 401) return 'invalid';
+      if (res.status === 401 || res.status === 403 || res.status === 404) {
+        // DEBUG PRINT - mark credentials invalid
+        console.log('[DEBUG] verifyAppleCredentials invalid status:', res.status);
+        return 'invalid';
+      }
+      // DEBUG PRINT - unexpected status from Apple
+      console.log('[DEBUG] verifyAppleCredentials unreachable status:', res.status);
       return 'unreachable';
-    } catch {
+    } catch (err) {
+      // DEBUG PRINT - error during fetch
+      console.log('[DEBUG] verifyAppleCredentials error:', err);
       return 'unreachable';
     }
   }
 
   async connectAppleCalendar(userId: string, email: string, password: string) {
+    // DEBUG PRINT - start connection attempt
+    console.log('[DEBUG] connectAppleCalendar start', { userId, email });
     const result = await this.verifyAppleCredentials(email, password);
+    // DEBUG PRINT - result of credential check
+    console.log('[DEBUG] connectAppleCalendar verify result:', result);
     if (result === 'invalid') throw new BadRequestException('Invalid Apple credentials');
     if (result === 'unreachable') throw new ServiceUnavailableException('Unable to reach Apple Calendar');
 


### PR DESCRIPTION
## Summary
- set `User-Agent` and `Accept` headers when verifying Apple Calendar credentials
- treat 404 responses as invalid credentials
- test invalid Apple credentials for 401/403/404 statuses
- add temporary debug output for Apple Calendar connection failures

## Testing
- `yarn install` *(succeeds with warnings)*
- `yarn test` *(fails: ts-jest peer dependency issue)*

------
https://chatgpt.com/codex/tasks/task_e_688104d170f88320b05a7fccc74375a4