### PR TITLE
Fix Apple calendar credential check

### DIFF
--- a/backend/src/integrations/integrations.service.spec.ts
+++ b/backend/src/integrations/integrations.service.spec.ts
@@ -29,9 +29,17 @@ describe('IntegrationsService - Apple Calendar', () => {
   });
 
   it('throws BadRequestException for invalid credentials', async () => {
-    (global as any).fetch = jest.fn().mockResolvedValue({ status: 401 });
-    await expect(
-      service.connectAppleCalendar('user1', 'bad@example.com', 'bad')
-    ).rejects.toBeInstanceOf(BadRequestException);
+    const mockRes = (status: number) => ({
+      status,
+      statusText: '',
+      headers: { entries: () => [] as any[] },
+      text: jest.fn().mockResolvedValue(''),
+    });
+    for (const status of [401, 403, 404]) {
+      (global as any).fetch = jest.fn().mockResolvedValue(mockRes(status));
+      await expect(
+        service.connectAppleCalendar('user1', 'bad@example.com', 'bad')
+      ).rejects.toBeInstanceOf(BadRequestException);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- set `Content-Type: text/xml` when verifying Apple Calendar credentials
- print response headers and body for easier debugging
- adjust tests to mock `fetch` response shape

## Testing
- `yarn test` *(fails: ts-jest peer dependency issue)*

------
https://chatgpt.com/codex/tasks/task_e_688104d170f88320b05a7fccc74375a4