### PR TITLE
Fix Apple calendar credential check

### DIFF
--- a/backend/src/integrations/integrations.service.spec.ts
+++ b/backend/src/integrations/integrations.service.spec.ts
@@ -29,9 +29,17 @@ describe('IntegrationsService - Apple Calendar', () => {
   });
 
   it('throws BadRequestException for invalid credentials', async () => {
-    (global as any).fetch = jest.fn().mockResolvedValue({ status: 401 });
-    await expect(
-      service.connectAppleCalendar('user1', 'bad@example.com', 'bad')
-    ).rejects.toBeInstanceOf(BadRequestException);
+    const mockRes = (status: number) => ({
+      status,
+      statusText: '',
+      headers: { entries: () => [] as any[] },
+      text: jest.fn().mockResolvedValue(''),
+    });
+    for (const status of [401, 403, 404]) {
+      (global as any).fetch = jest.fn().mockResolvedValue(mockRes(status));
+      await expect(
+        service.connectAppleCalendar('user1', 'bad@example.com', 'bad')
+      ).rejects.toBeInstanceOf(BadRequestException);
+    }
   });
 });

--- a/backend/src/integrations/integrations.service.ts
+++ b/backend/src/integrations/integrations.service.ts
@@ -266,24 +266,47 @@ export class IntegrationsService {
 
   private async verifyAppleCredentials(email: string, password: string): Promise<'ok' | 'invalid' | 'unreachable'> {
     try {
-      const res = await fetch('https://caldav.icloud.com/', {
+      // DEBUG PRINT - remove when Apple integration is stable
+      const requestOptions = {
         method: 'PROPFIND',
         headers: {
           Depth: '0',
           Authorization: 'Basic ' + Buffer.from(`${email}:${password}`).toString('base64'),
+          'Content-Type': 'text/xml',
+          'User-Agent': 'calendarify-caldav',
+          Accept: 'application/xml,text/xml;q=0.9,*/*;q=0.8',
         },
         body: `<?xml version="1.0" encoding="UTF-8"?>\n<propfind xmlns="DAV:">\n  <prop><current-user-principal/></prop>\n</propfind>`,
-      });
+      };
+      console.log('[DEBUG] verifyAppleCredentials request for', email, requestOptions);
+      const res = await fetch('https://caldav.icloud.com/', requestOptions);
+      // DEBUG PRINT - show status returned by Apple
+      console.log('[DEBUG] verifyAppleCredentials response status:', res.status, res.statusText);
+      console.log('[DEBUG] verifyAppleCredentials response headers:', Object.fromEntries(res.headers.entries()));
+      const bodyText = await res.text();
+      console.log('[DEBUG] verifyAppleCredentials response body:', bodyText.slice(0, 200));
       if (res.status === 207) return 'ok';
-      if (res.status === 401) return 'invalid';
+      if (res.status === 401 || res.status === 403 || res.status === 404) {
+        // DEBUG PRINT - mark credentials invalid
+        console.log('[DEBUG] verifyAppleCredentials invalid status:', res.status);
+        return 'invalid';
+      }
+      // DEBUG PRINT - unexpected status from Apple
+      console.log('[DEBUG] verifyAppleCredentials unreachable status:', res.status);
       return 'unreachable';
-    } catch {
+    } catch (err) {
+      // DEBUG PRINT - error during fetch
+      console.log('[DEBUG] verifyAppleCredentials error:', err);
       return 'unreachable';
     }
   }
 
   async connectAppleCalendar(userId: string, email: string, password: string) {
+    // DEBUG PRINT - start connection attempt
+    console.log('[DEBUG] connectAppleCalendar start', { userId, email });
     const result = await this.verifyAppleCredentials(email, password);
+    // DEBUG PRINT - result of credential check
+    console.log('[DEBUG] connectAppleCalendar verify result:', result);
     if (result === 'invalid') throw new BadRequestException('Invalid Apple credentials');
     if (result === 'unreachable') throw new ServiceUnavailableException('Unable to reach Apple Calendar');
 


### PR DESCRIPTION
## Summary
- set `Content-Type: text/xml` when verifying Apple Calendar credentials
- print response headers and body for easier debugging
- adjust tests to mock `fetch` response shape
- add more verbose debug logging showing full request options and status text

## Testing
- `yarn test` *(fails: ts-jest peer dependency issue)*

------
https://chatgpt.com/codex/tasks/task_e_688104d170f88320b05a7fccc74375a4