### PR TITLE
Remove Apple calendar chooser

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -3365,18 +3365,8 @@
       });
       if (res.ok) {
         showNotification('Apple Calendar connected');
-        const listRes = await fetch(`${API_URL}/integrations/apple/calendars`, {
-          headers: { Authorization: `Bearer ${clean}` }
-        });
-        if (listRes.ok) {
-          const data = await listRes.json();
-          populateAppleCalendarList(data.calendars);
-          closeConnectAppleModal();
-          openSelectAppleModal();
-        } else {
-          updateAppleCalendarButton();
-          closeConnectAppleModal();
-        }
+        updateAppleCalendarButton();
+        closeConnectAppleModal();
       } else if (res.status === 400) {
         showNotification('Invalid Apple credentials');
       } else if (res.status === 503) {
@@ -3386,46 +3376,6 @@
       }
     }
     window.submitAppleConnect = submitAppleConnect;
-
-    function populateAppleCalendarList(cals) {
-      const select = document.getElementById('apple-calendar-list');
-      select.innerHTML = '';
-      cals.forEach(c => {
-        const opt = document.createElement('option');
-        opt.value = c.href;
-        opt.textContent = c.name || c.href;
-        select.appendChild(opt);
-      });
-    }
-
-    function openSelectAppleModal() {
-      document.getElementById('modal-backdrop').classList.remove('hidden');
-      document.getElementById('select-apple-calendar-modal').classList.remove('hidden');
-    }
-    function closeSelectAppleModal() {
-      document.getElementById('modal-backdrop').classList.add('hidden');
-      document.getElementById('select-apple-calendar-modal').classList.add('hidden');
-    }
-    async function submitAppleCalendarChoice() {
-      const href = document.getElementById('apple-calendar-list').value;
-      const token = localStorage.getItem('calendarify-token');
-      if (!token) return;
-      const clean = token.replace(/^\"|\"$/g, '');
-      const res = await fetch(`${API_URL}/integrations/apple/select`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
-        body: JSON.stringify({ href }),
-      });
-      if (res.ok) {
-        showNotification('Apple calendar selected');
-        updateAppleCalendarButton();
-      } else {
-        showNotification('Failed to save calendar');
-      }
-      closeSelectAppleModal();
-    }
-    window.closeSelectAppleModal = closeSelectAppleModal;
-    window.submitAppleCalendarChoice = submitAppleCalendarChoice;
 
     function openDisconnectAppleModal() {
       document.getElementById('modal-backdrop').classList.remove('hidden');

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -904,29 +904,7 @@
         </div>
       </div>
     </div>
-  </div>
-
-  <!-- Select Apple Calendar Modal -->
-  <div id="select-apple-calendar-modal" class="fixed inset-0 z-50 hidden">
-    <div class="flex items-center justify-center min-h-screen p-4">
-      <div class="bg-[#1E3A34] rounded-xl shadow-2xl w-full max-w-md">
-        <div class="flex items-center justify-between p-6 border-b border-[#2C4A43]">
-          <h2 class="text-xl font-bold text-white">Choose Calendar</h2>
-          <button onclick="closeSelectAppleModal()" class="text-[#A3B3AF] hover:text-white transition-colors">
-            <span class="material-icons-outlined text-2xl">close</span>
-          </button>
-        </div>
-        <form onsubmit="submitAppleCalendarChoice(); return false;" class="p-6 space-y-4">
-          <select id="apple-calendar-list" class="w-full bg-[#19342e] border border-[#2C4A43] text-[#E0E0E0] rounded-lg px-4 py-3 focus:border-[#34D399] focus:ring-2 focus:ring-[#34D399]"></select>
-          <div class="flex items-center justify-end gap-3 pt-4 border-t border-[#2C4A43]">
-            <button type="button" onclick="closeSelectAppleModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white transition-colors font-medium">Cancel</button>
-            <button type="submit" class="bg-[#34D399] text-[#1A2E29] px-6 py-3 rounded-lg hover:bg-[#2fb67c] transition-colors font-bold">Save</button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-
+</div>
 
   <!-- Create Event Type Modal -->
   <div id="create-event-type-modal" class="fixed inset-0 z-50 hidden">


### PR DESCRIPTION
## Summary
- remove Apple calendar selection modal from the dashboard
- simplify Apple connect handler to skip the calendar chooser

## Testing
- `npm test` *(fails: cannot find module 'node-fetch' in integrations.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68823f861520832083e3bc544bdd591a