### PR TITLE
Implement booking links for event types

### DIFF
--- a/backend/src/event-types/event-types.controller.ts
+++ b/backend/src/event-types/event-types.controller.ts
@@ -18,6 +18,11 @@ export class EventTypesController {
     return this.events.list(req.user.userId);
   }
 
+  @Get('slug/:slug')
+  findBySlug(@Param('slug') slug: string) {
+    return this.events.findBySlug(slug);
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get(':id')
   findOne(@Request() req, @Param('id') id: string) {

--- a/backend/src/event-types/event-types.service.ts
+++ b/backend/src/event-types/event-types.service.ts
@@ -28,6 +28,10 @@ export class EventTypesService {
     return this.prisma.eventType.findUnique({ where: { id } });
   }
 
+  findBySlug(slug: string) {
+    return this.prisma.eventType.findUnique({ where: { slug } });
+  }
+
   update(id: string, data: Partial<EventType>) {
     return this.prisma.eventType.update({ where: { id }, data });
   }

--- a/booking/index.html
+++ b/booking/index.html
@@ -219,7 +219,7 @@
             <div class="flex flex-col lg:flex-row lg:space-x-8 main-content" id="mainContent">
                 <div class="lg:w-1/2">
                     <p class="text-sm text-gray-400">Welcome back, <span id="username" class="text-[#34D399]"></span></p>
-                    <h2 class="text-3xl font-bold text-white mt-1 mb-4">Your Calendar</h2>
+                    <h2 id="eventTitle" class="text-3xl font-bold text-white mt-1 mb-4"></h2>
                     <div class="flex items-center text-gray-400 mb-2">
                         <span class="material-icons-outlined mr-2">schedule</span>
                         <span>Manage your availability</span>
@@ -271,6 +271,20 @@
         document.addEventListener('DOMContentLoaded', function() {
             const params = new URLSearchParams(window.location.search);
             document.getElementById('username').textContent = params.get('user') || 'User';
+
+            const slug = params.get('event');
+            if (!slug) {
+                window.location.replace('/');
+                return;
+            }
+
+            const eventTypes = JSON.parse(localStorage.getItem('calendarify-event-types') || '[]');
+            const event = eventTypes.find(e => e.slug === slug);
+            if (!event) {
+                document.body.innerHTML = '<div class="text-center mt-20 text-red-500">Invalid event link</div>';
+                return;
+            }
+            document.getElementById('eventTitle').textContent = `Book: ${event.name}`;
             
             let currentDate = new Date();
             let selectedDate = null; // No initial selection

--- a/server.js
+++ b/server.js
@@ -20,7 +20,8 @@ http.createServer((req, res) => {
   // Log incoming request
   console.log(`INCOMING: ${req.method} ${req.url}`);
 
-  let reqPath = req.url.split('?')[0];
+  const urlObj = new URL(req.url, `http://${req.headers.host}`);
+  let reqPath = urlObj.pathname;
   if (reqPath === '/' || reqPath === '') {
     reqPath = '/index.html';
   }
@@ -28,6 +29,21 @@ http.createServer((req, res) => {
   // Special handling for /sign-up and /sign-up/
   if (reqPath === '/sign-up' || reqPath === '/sign-up/') {
     reqPath = '/sign-up/index.html';
+  }
+
+  // Prevent access to booking page without an event slug
+  if (
+    reqPath === '/booking' ||
+    reqPath === '/booking/' ||
+    reqPath === '/booking/index.html'
+  ) {
+    if (!urlObj.searchParams.get('event')) {
+      res.writeHead(404);
+      res.end('Not found');
+      console.log(`OUTGOING: 404 ${req.url} (missing event)`);
+      return;
+    }
+    reqPath = '/booking/index.html';
   }
 
   let filePath = path.join(rootDir, reqPath);


### PR DESCRIPTION
## Summary
- generate slugs when creating, cloning and editing event types
- add a default slug on first boot
- copy booking links using the slug
- load booking page only with a valid event slug
- block `/booking` path without a slug
- expose `GET /event-types/slug/:slug` to fetch by slug

## Testing
- `npm test` *(fails: Required package missing from disk)*

------
https://chatgpt.com/codex/tasks/task_e_68835e89a8d083208dab2865e4689a07