### PR TITLE
Implement booking link domains and unique slugs

### DIFF
--- a/backend/prisma/migrations/0004_add_display_name/migration.sql
+++ b/backend/prisma/migrations/0004_add_display_name/migration.sql
@@ -1,0 +1,3 @@
+-- Add display_name column and unique constraint
+ALTER TABLE "User" ADD COLUMN "display_name" TEXT;
+CREATE UNIQUE INDEX "User_display_name_key" ON "User"("display_name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,6 +10,7 @@ generator client {
 model User {
   id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   email       String   @unique
+  display_name String? @unique
   name        String?
   password    String
   created_at  DateTime @default(now())

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -2,4 +2,5 @@ export class RegisterDto {
   email: string;
   password: string;
   name?: string;
+  displayName?: string;
 }

--- a/backend/src/event-types/event-types.controller.ts
+++ b/backend/src/event-types/event-types.controller.ts
@@ -18,6 +18,11 @@ export class EventTypesController {
     return this.events.list(req.user.userId);
   }
 
+  @Get('slug/:slug')
+  findBySlug(@Param('slug') slug: string) {
+    return this.events.findBySlug(slug);
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get(':id')
   findOne(@Request() req, @Param('id') id: string) {

--- a/backend/src/event-types/event-types.service.ts
+++ b/backend/src/event-types/event-types.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
+import { generateUniqueSlug } from './slug.utils';
 
 export interface EventType {
   id: string;
@@ -18,9 +19,10 @@ export class EventTypesService {
     return this.prisma.eventType.findMany({ where: { user_id: userId }, orderBy: { created_at: 'asc' } });
   }
 
-  create(userId: string, data: Omit<EventType, 'id' | 'userId'>) {
+  async create(userId: string, data: Omit<EventType, 'id' | 'userId'>) {
+    const slug = await generateUniqueSlug(this.prisma, data.slug || data.title);
     return this.prisma.eventType.create({
-      data: { user_id: userId, ...data },
+      data: { user_id: userId, ...data, slug },
     });
   }
 
@@ -28,7 +30,15 @@ export class EventTypesService {
     return this.prisma.eventType.findUnique({ where: { id } });
   }
 
-  update(id: string, data: Partial<EventType>) {
+  findBySlug(slug: string) {
+    return this.prisma.eventType.findUnique({ where: { slug } });
+  }
+
+  async update(id: string, data: Partial<EventType>) {
+    if (data.title || data.slug) {
+      const source = data.slug || data.title!;
+      data.slug = await generateUniqueSlug(this.prisma, source, id);
+    }
     return this.prisma.eventType.update({ where: { id }, data });
   }
 

--- a/backend/src/event-types/slug.utils.ts
+++ b/backend/src/event-types/slug.utils.ts
@@ -1,0 +1,44 @@
+export function slugify(text: string): string {
+  return text
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+export async function generateUniqueSlug(
+  prisma: { eventType: { findUnique: (args: any) => Promise<any> } },
+  text: string,
+  excludeId?: string,
+): Promise<string> {
+  const base = slugify(text);
+  let slug = base;
+  let i = 1;
+  while (true) {
+    const existing = await prisma.eventType.findUnique({ where: { slug } });
+    if (!existing || existing.id === excludeId) {
+      break;
+    }
+    slug = `${base}-${i++}`;
+  }
+  return slug;
+}
+
+export async function generateUniqueUserSlug(
+  prisma: { user: { findUnique: (args: any) => Promise<any> } },
+  text: string,
+  excludeId?: string,
+): Promise<string> {
+  const base = slugify(text);
+  let slug = base;
+  let i = 1;
+  while (true) {
+    const existing = await prisma.user.findUnique({ where: { display_name: slug } });
+    if (!existing || existing.id === excludeId) {
+      break;
+    }
+    slug = `${base}-${i++}`;
+  }
+  return slug;
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Patch, Request, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Request, UseGuards, Param } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { UsersService } from './users.service';
 import { UserStateService } from './user-state.service';
@@ -17,6 +17,11 @@ export class UsersController {
   @Patch('me')
   update(@Request() req, @Body() body: any) {
     return this.users.update(req.user.userId, body);
+  }
+
+  @Get('display/:name')
+  byDisplayName(@Param('name') name: string) {
+    return this.users.findByDisplayName(name);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
+import { generateUniqueUserSlug } from '../event-types/slug.utils';
 
 @Injectable()
 export class UsersService {
@@ -9,7 +10,15 @@ export class UsersService {
     return this.prisma.user.findUnique({ where: { id } });
   }
 
-  update(id: string, data: any) {
+  findByDisplayName(displayName: string) {
+    return this.prisma.user.findUnique({ where: { display_name: displayName } });
+  }
+
+  async update(id: string, data: any) {
+    if (data.displayName) {
+      data.display_name = await generateUniqueUserSlug(this.prisma, data.displayName, id);
+      delete data.displayName;
+    }
     return this.prisma.user.update({ where: { id }, data });
   }
 }

--- a/booking/index.html
+++ b/booking/index.html
@@ -219,7 +219,7 @@
             <div class="flex flex-col lg:flex-row lg:space-x-8 main-content" id="mainContent">
                 <div class="lg:w-1/2">
                     <p class="text-sm text-gray-400">Welcome back, <span id="username" class="text-[#34D399]"></span></p>
-                    <h2 class="text-3xl font-bold text-white mt-1 mb-4">Your Calendar</h2>
+                    <h2 id="eventTitle" class="text-3xl font-bold text-white mt-1 mb-4"></h2>
                     <div class="flex items-center text-gray-400 mb-2">
                         <span class="material-icons-outlined mr-2">schedule</span>
                         <span>Manage your availability</span>
@@ -268,9 +268,34 @@
     </footer>
 
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const params = new URLSearchParams(window.location.search);
-            document.getElementById('username').textContent = params.get('user') || 'User';
+        document.addEventListener('DOMContentLoaded', async function() {
+            const parts = window.location.pathname.split('/').filter(Boolean);
+            let display = '';
+            let slug = '';
+            if (parts.length >= 3 && parts[0] === 'booking') {
+                display = decodeURIComponent(parts[1]);
+                slug = parts[2];
+            } else {
+                const params = new URLSearchParams(window.location.search);
+                display = params.get('user') || '';
+                slug = params.get('event') || '';
+            }
+            if (!slug || !display) {
+                window.location.replace('/');
+                return;
+            }
+            document.getElementById('username').textContent = display;
+
+            window.API_URL = 'http://localhost:3001/api';
+            try {
+                const res = await fetch(`${API_URL}/event-types/slug/${slug}`);
+                if (!res.ok) throw new Error('not found');
+                const event = await res.json();
+                document.getElementById('eventTitle').textContent = `Book: ${event.title}`;
+            } catch (e) {
+                document.body.innerHTML = '<div class="text-center mt-20 text-red-500">Invalid event link</div>';
+                return;
+            }
             
             let currentDate = new Date();
             let selectedDate = null; // No initial selection

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -288,8 +288,10 @@
     }
 
     // Utility functions
-    function copyLink(link) {
-      navigator.clipboard.writeText(link);
+    function copyLink(slug) {
+      const prefix = window.FRONTEND_URL || window.location.origin;
+      const display = localStorage.getItem('calendarify-display-name') || 'user';
+      navigator.clipboard.writeText(`${prefix}/booking/${encodeURIComponent(display)}/${slug}`);
       showNotification('Link copied to clipboard');
     }
 
@@ -302,6 +304,25 @@
     function closeShareModal() {
       document.getElementById('share-modal').classList.add('hidden');
       document.getElementById('modal-backdrop').classList.add('hidden');
+    }
+
+    function slugify(text) {
+      return text
+        .toString()
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '');
+    }
+
+    function generateSlug(name, existing) {
+      const base = slugify(name);
+      let slug = base;
+      let i = 1;
+      while (existing.some(e => e.slug === slug)) {
+        slug = `${base}-${i++}`;
+      }
+      return slug;
     }
 
     function toggleCreateMenu() {
@@ -663,13 +684,14 @@
       const token = localStorage.getItem('calendarify-token');
       if (token) {
         try {
-          // Remove surrounding quotes if they exist
           const cleanToken = token.replace(/^"|"$/g, "");
           const res = await fetch(`${API_URL}/users/me`, { headers: { Authorization: `Bearer ${cleanToken}` } });
           if (res.ok) {
             const data = await res.json();
             document.getElementById('profile-name').textContent = data.name || 'User';
             document.getElementById('profile-email').textContent = data.email || '';
+            document.getElementById('profile-displayname').textContent = data.display_name || '';
+            localStorage.setItem('calendarify-display-name', data.display_name || '');
           } else {
             console.error('Failed to load profile: HTTP', res.status);
           }
@@ -683,6 +705,45 @@
       document.getElementById('profile-modal').classList.add('hidden');
       document.getElementById('modal-backdrop').classList.add('hidden');
     }
+
+    function openChangeDisplayNameModal() {
+      document.getElementById('change-displayname-input').value = localStorage.getItem('calendarify-display-name') || '';
+      document.getElementById('change-displayname-modal').classList.remove('hidden');
+      document.getElementById('modal-backdrop').classList.remove('hidden');
+    }
+
+    function closeChangeDisplayNameModal() {
+      document.getElementById('change-displayname-modal').classList.add('hidden');
+      document.getElementById('modal-backdrop').classList.add('hidden');
+    }
+
+    async function saveDisplayName() {
+      const input = document.getElementById('change-displayname-input');
+      const newName = input.value.trim();
+      if (!newName) return;
+      const token = localStorage.getItem('calendarify-token');
+      if (!token) return;
+      const clean = token.replace(/^"|"$/g, '');
+      const res = await fetch(`${API_URL}/users/me`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+        body: JSON.stringify({ displayName: newName })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        document.getElementById('profile-displayname').textContent = data.display_name;
+        localStorage.setItem('calendarify-display-name', data.display_name);
+        showNotification('Display name updated');
+      } else {
+        const text = await res.text();
+        showNotification(text || 'Failed to update');
+      }
+      closeChangeDisplayNameModal();
+    }
+
+    window.openChangeDisplayNameModal = openChangeDisplayNameModal;
+    window.closeChangeDisplayNameModal = closeChangeDisplayNameModal;
+    window.saveDisplayName = saveDisplayName;
 
     // Close modals when clicking backdrop
     document.getElementById('modal-backdrop').addEventListener('click', function() {
@@ -1372,8 +1433,12 @@
         return;
       }
 
+      let eventTypes = JSON.parse(localStorage.getItem('calendarify-event-types') || '[]');
+      const slug = generateSlug(name, eventTypes);
+
       const eventTypeData = {
         name,
+        slug,
         duration: parseInt(duration),
         eventType,
         attendeeLimit: eventType !== '1-on-1' ? parseInt(attendeeLimit) : 1,
@@ -1412,9 +1477,6 @@
         id: Date.now().toString()
       };
 
-      // Get existing event types from localStorage
-      let eventTypes = JSON.parse(localStorage.getItem('calendarify-event-types') || '[]');
-      
       // Add new event type
       eventTypes.push(eventTypeData);
       
@@ -1553,7 +1615,7 @@
               <button class="text-[#A3B3AF] hover:text-[#34D399]" title="Favorite"><span class="material-icons-outlined">star_border</span></button>
             </div>
             <div class="flex gap-2 mt-2">
-              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="copyLink('https://cal.example/${eventType.id}')"><span class="material-icons-outlined text-base">link</span>Copy link</button>
+              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="copyLink('${eventType.slug}')"><span class="material-icons-outlined text-base">link</span>Copy link</button>
               <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="openShareModal('${eventType.name}')"><span class="material-icons-outlined text-base">share</span>Share</button>
               <div class="relative">
                 <button class="text-[#A3B3AF] hover:text-[#34D399] px-2 py-1 rounded-full" onclick="toggleCardMenu(this)"><span class="material-icons-outlined">more_vert</span></button>
@@ -1603,14 +1665,16 @@
     function cloneEventType(id) {
       let eventTypes = JSON.parse(localStorage.getItem('calendarify-event-types') || '[]');
       const originalEventType = eventTypes.find(eventType => eventType.id === id);
-      
+
       if (originalEventType) {
         const clonedEventType = {
           ...originalEventType,
           name: `${originalEventType.name} (Copy)`,
           id: Date.now().toString()
         };
-        
+
+        clonedEventType.slug = generateSlug(clonedEventType.name, eventTypes);
+
         eventTypes.push(clonedEventType);
         localStorage.setItem('calendarify-event-types', JSON.stringify(eventTypes));
         renderEventTypes();
@@ -1734,9 +1798,17 @@
       }
 
       // Update the event type data
+      let eventTypes = JSON.parse(localStorage.getItem('calendarify-event-types') || '[]');
+      const existing = eventTypes.filter(et => et.id !== eventType.id);
+      let slug = eventType.slug;
+      if (name !== eventType.name) {
+        slug = generateSlug(name, existing);
+      }
+
       const updatedEventType = {
         ...eventType,
         name,
+        slug,
         duration: parseInt(duration),
         eventType: eventTypeValue,
         attendeeLimit: eventTypeValue !== '1-on-1' ? parseInt(attendeeLimit) : 1,
@@ -1775,7 +1847,7 @@
       };
 
       // Update in localStorage
-      let eventTypes = JSON.parse(localStorage.getItem('calendarify-event-types') || '[]');
+      eventTypes = JSON.parse(localStorage.getItem('calendarify-event-types') || '[]');
       const index = eventTypes.findIndex(et => et.id === eventType.id);
       if (index !== -1) {
         eventTypes[index] = updatedEventType;
@@ -1841,6 +1913,7 @@
       if (eventTypes.length === 0) {
         eventTypes.push({
           name: '30-min Intro Call',
+          slug: '30-min-intro-call',
           duration: 30,
           eventType: '1-on-1',
           attendeeLimit: 1,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <link rel="stylesheet" href="/dashboard/dashboard.css">
   <script src="/auth.js"></script>
+  <script src="/config.js"></script>
   <script src="/dashboard/dashboard.js" defer></script>
 </head>
 <body id="dashboard-body" class="flex min-h-screen hidden">
@@ -797,7 +798,7 @@
   </div>
   
   <!-- Profile Modal -->
-  <div id="profile-modal" class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-[#1E3A34] rounded-xl p-8 z-50 hidden" style="min-width:300px;">
+  <div id="profile-modal" class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-[#1E3A34] rounded-xl shadow-2xl p-8 z-50 hidden" style="min-width:320px; max-width:400px;">
     <div class="flex items-center justify-between mb-4">
       <h3 class="text-lg font-bold text-white">Your Profile</h3>
       <button onclick="closeProfileModal()" class="text-[#A3B3AF] hover:text-white transition-colors">
@@ -807,10 +808,22 @@
     <div class="space-y-2">
       <p><span class="text-[#A3B3AF]">Name:</span> <span id="profile-name" class="text-white"></span></p>
       <p><span class="text-[#A3B3AF]">Email:</span> <span id="profile-email" class="text-white"></span></p>
+      <p><span class="text-[#A3B3AF]">Display Name:</span> <span id="profile-displayname" class="text-white"></span> <button class="btn-secondary text-xs ml-2" onclick="openChangeDisplayNameModal()">Change</button></p>
       <p><span class="text-[#A3B3AF]">Timezone:</span> <span id="profile-timezone" class="text-white"></span></p>
     </div>
     <div class="mt-6 text-right">
       <button class="btn-secondary" onclick="closeProfileModal()">Close</button>
+    </div>
+  </div>
+
+  <!-- Change Display Name Modal -->
+  <div id="change-displayname-modal" class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-[#1E3A34] rounded-xl p-8 z-50 hidden" style="min-width:300px;">
+    <h3 class="text-lg font-bold text-white mb-4">Change Display Name</h3>
+    <p class="text-red-500 font-semibold text-sm mb-4">Changing your display name will break all existing booking links. Are you sure?</p>
+    <input id="change-displayname-input" type="text" class="w-full bg-[#19342e] border border-[#2C4A43] text-[#E0E0E0] rounded-lg px-4 py-3 focus:border-[#34D399] focus:ring-2 focus:ring-[#34D399] mb-4" />
+    <div class="text-right space-x-2">
+      <button class="btn-secondary" onclick="closeChangeDisplayNameModal()">Cancel</button>
+      <button class="bg-[#34D399] text-[#1A2E29] px-4 py-2 rounded-lg font-bold" onclick="saveDisplayName()">Save</button>
     </div>
   </div>
 

--- a/server.js
+++ b/server.js
@@ -20,14 +20,34 @@ http.createServer((req, res) => {
   // Log incoming request
   console.log(`INCOMING: ${req.method} ${req.url}`);
 
-  let reqPath = req.url.split('?')[0];
+  const urlObj = new URL(req.url, `http://${req.headers.host}`);
+  let reqPath = urlObj.pathname;
   if (reqPath === '/' || reqPath === '') {
     reqPath = '/index.html';
+  }
+
+  if (reqPath === '/config.js') {
+    const frontend = process.env.FRONTEND_URL || '';
+    res.setHeader('Content-Type', 'text/javascript');
+    res.end(`window.FRONTEND_URL = '${frontend}';`);
+    return;
   }
 
   // Special handling for /sign-up and /sign-up/
   if (reqPath === '/sign-up' || reqPath === '/sign-up/') {
     reqPath = '/sign-up/index.html';
+  }
+
+  // Prevent access to booking page without required parts
+  if (reqPath.startsWith('/booking')) {
+    const parts = reqPath.split('/').filter(Boolean);
+    if (parts.length < 3) {
+      res.writeHead(404);
+      res.end('Not found');
+      console.log(`OUTGOING: 404 ${req.url} (missing slug)`);
+      return;
+    }
+    reqPath = '/booking/index.html';
   }
 
   let filePath = path.join(rootDir, reqPath);


### PR DESCRIPTION
## Summary
- add `PREPEND_URL` example entry
- expose `/config.js` from the static server
- load `/config.js` in dashboard
- prefix copied booking links with configured domain
- generate unique slugs in the backend
- enforce unique user display names and add change display name modal
- include display name in booking URLs

## Testing
- `npm test` *(fails: Required package missing from disk)*

------
https://chatgpt.com/codex/tasks/task_e_68835e89a8d083208dab2865e4689a07