### PR TITLE
Fix create event modal layout

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1001,7 +1001,6 @@
               <label for="event-type-description" class="block text-[#A3B3AF] text-sm font-medium mb-2">Description</label>
               <textarea id="event-type-description" rows="3" class="w-full bg-[#19342e] border border-[#2C4A43] text-[#E0E0E0] rounded-lg px-4 py-3 focus:border-[#34D399] focus:ring-2 focus:ring-[#34D399] transition-colors resize-none" placeholder="Brief description of what this meeting is about"></textarea>
             </div>
-            </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>


### PR DESCRIPTION
## Summary
- fix closing div in create event type modal

## Testing
- `yarn test` *(fails: PrismaClient not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836da5d26883209f42f58500133c49