### PR TITLE
Fix booking link for default event type

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -296,8 +296,14 @@
       showNotification('Link copied to clipboard');
     }
 
-    function openShareModal(title) {
+    function openShareModal(title, slug) {
+      const prefix = window.PREPEND_URL || window.FRONTEND_URL || window.location.origin;
+      const display = localStorage.getItem('calendarify-display-name') || 'user';
+      const link = `${prefix}/booking/${encodeURIComponent(display)}/${slug}`;
       document.getElementById('share-modal-title').textContent = title;
+      document.getElementById('share-modal-link').value = link;
+      const copyBtn = document.getElementById('share-modal-copy-btn');
+      copyBtn.onclick = () => copyLink(slug);
       document.getElementById('share-modal').classList.remove('hidden');
       document.getElementById('modal-backdrop').classList.remove('hidden');
     }
@@ -1634,7 +1640,7 @@
             </div>
             <div class="flex gap-2 mt-2">
               <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="copyLink('${eventType.slug}')"><span class="material-icons-outlined text-base">link</span>Copy link</button>
-              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="openShareModal('${eventType.name}')"><span class="material-icons-outlined text-base">share</span>Share</button>
+              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="openShareModal('${eventType.name}','${eventType.slug}')"><span class="material-icons-outlined text-base">share</span>Share</button>
               <div class="relative">
                 <button class="text-[#A3B3AF] hover:text-[#34D399] px-2 py-1 rounded-full" onclick="toggleCardMenu(this)"><span class="material-icons-outlined">more_vert</span></button>
                 <div class="absolute right-0 mt-2 w-40 bg-[#1E3A34] rounded-lg shadow-lg py-2 z-50 hidden card-menu">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -119,8 +119,8 @@
               <button class="text-[#A3B3AF] hover:text-[#34D399]" title="Favorite"><span class="material-icons-outlined">star_border</span></button>
           </div>
             <div class="flex gap-2 mt-2">
-              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="copyLink('https://cal.example/intro')"><span class="material-icons-outlined text-base">link</span>Copy link</button>
-              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="openShareModal('30-min Intro Call')"><span class="material-icons-outlined text-base">share</span>Share</button>
+              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="copyLink('30-min-intro-call')"><span class="material-icons-outlined text-base">link</span>Copy link</button>
+              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="openShareModal('30-min Intro Call','30-min-intro-call')"><span class="material-icons-outlined text-base">share</span>Share</button>
               <div class="relative">
                 <button class="text-[#A3B3AF] hover:text-[#34D399] px-2 py-1 rounded-full" onclick="toggleCardMenu(this)"><span class="material-icons-outlined">more_vert</span></button>
                 <div class="absolute right-0 mt-2 w-40 bg-[#1E3A34] rounded-lg shadow-lg py-2 z-50 hidden card-menu">
@@ -640,8 +640,8 @@
   <div id="share-modal" class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-[#1E3A34] rounded-xl p-8 z-50 hidden" style="min-width:300px;">
     <h3 class="text-lg font-bold text-white mb-4">Share "<span id="share-modal-title"></span>"</h3>
     <div class="flex gap-2 mb-4">
-      <input type="text" class="input-field flex-1" value="https://cal.example/intro" readonly>
-      <button class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold" onclick="copyLink('https://cal.example/intro')">Copy</button>
+      <input id="share-modal-link" type="text" class="input-field flex-1" readonly>
+      <button id="share-modal-copy-btn" class="bg-[#34D399] text-[#1A2E29] px-3 py-1 rounded-lg font-bold">Copy</button>
     </div>
     <button class="btn-secondary" onclick="closeShareModal()">Close</button>
   </div>


### PR DESCRIPTION
## Summary
- fix static link in default event card
- update share modal to display dynamic event link
- make `openShareModal` accept slug parameter and update calls

## Testing
- `yarn install`
- `yarn test` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68837024f3b48320b3fc41e33e8c0845