### PR TITLE
Fix state not saving on unload

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -99,10 +99,10 @@
     async function syncState() {
       const token = localStorage.getItem("calendarify-token");
       if (!token) return;
-      
+
       // Remove surrounding quotes if they exist
       const cleanToken = token.replace(/^"|"$/g, "");
-      
+
       await fetch(`${API_URL}/users/me/state`, {
         method: "PATCH",
         headers: {
@@ -110,6 +110,7 @@
           Authorization: `Bearer ${cleanToken}`,
         },
         body: JSON.stringify(collectState()),
+        keepalive: true,
       });
     }
 


### PR DESCRIPTION
## Summary
- keep state sync alive on page unload so availability preferences persist

## Testing
- `yarn test` *(fails: Module '"@prisma/client"' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68838cc591b483209e4a4b3d628fea2c