### PR TITLE
Fix state not saving on unload

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -143,7 +143,9 @@ async function initAuth(bodyId, onSuccess) {
       const el = document.getElementById(bodyId);
       if (el) el.classList.remove('hidden');
     }
-    if (typeof onSuccess === 'function') onSuccess();
+    if (typeof onSuccess === 'function') {
+      await onSuccess();
+    }
   }
 }
 

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -99,10 +99,10 @@
     async function syncState() {
       const token = localStorage.getItem("calendarify-token");
       if (!token) return;
-      
+
       // Remove surrounding quotes if they exist
       const cleanToken = token.replace(/^"|"$/g, "");
-      
+
       await fetch(`${API_URL}/users/me/state`, {
         method: "PATCH",
         headers: {
@@ -110,6 +110,7 @@
           Authorization: `Bearer ${cleanToken}`,
         },
         body: JSON.stringify(collectState()),
+        keepalive: true,
       });
     }
 
@@ -931,6 +932,8 @@
 
     // Initialize the dashboard
     document.addEventListener('DOMContentLoaded', async function() {
+      await initAuth('dashboard-body', loadState);
+
       updateClockFormatUI();
       updateAllCustomTimePickers();
       setupTimeInputListeners();
@@ -3263,7 +3266,6 @@
       document.getElementById('global-search-results').classList.add('hidden');
     }
 
-    initAuth('dashboard-body', loadState);
 
     function updateGoogleCalendarButton() {
       const btn = document.getElementById('google-calendar-connect-btn');


### PR DESCRIPTION
## Summary
- keep state sync alive on page unload so availability preferences persist
- wait for auth+state load before dashboard init

## Testing
- `yarn test` *(fails: Missing package: jest@virtual...)*

------
https://chatgpt.com/codex/tasks/task_e_68838cc591b483209e4a4b3d628fea2c