### PR TITLE
Fix dashboard availability persistence

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -143,7 +143,9 @@ async function initAuth(bodyId, onSuccess) {
       const el = document.getElementById(bodyId);
       if (el) el.classList.remove('hidden');
     }
-    if (typeof onSuccess === 'function') onSuccess();
+    if (typeof onSuccess === 'function') {
+      await onSuccess();
+    }
   }
 }
 

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -99,10 +99,10 @@
     async function syncState() {
       const token = localStorage.getItem("calendarify-token");
       if (!token) return;
-      
+
       // Remove surrounding quotes if they exist
       const cleanToken = token.replace(/^"|"$/g, "");
-      
+
       await fetch(`${API_URL}/users/me/state`, {
         method: "PATCH",
         headers: {
@@ -110,6 +110,7 @@
           Authorization: `Bearer ${cleanToken}`,
         },
         body: JSON.stringify(collectState()),
+        keepalive: true,
       });
     }
 
@@ -400,6 +401,7 @@
       };
       
       localStorage.setItem('calendarify-overrides', JSON.stringify(calendarOverrides));
+      syncState();
       
       // Update calendar display
       renderCalendar();
@@ -420,6 +422,7 @@
       // Remove override from localStorage
       delete calendarOverrides[dateString];
       localStorage.setItem('calendarify-overrides', JSON.stringify(calendarOverrides));
+      syncState();
       
       // Update calendar display
       renderCalendar();
@@ -931,6 +934,8 @@
 
     // Initialize the dashboard
     document.addEventListener('DOMContentLoaded', async function() {
+      await initAuth('dashboard-body', loadState);
+
       updateClockFormatUI();
       updateAllCustomTimePickers();
       setupTimeInputListeners();
@@ -1035,6 +1040,7 @@
           end: inputs[1].value || inputs[1].placeholder,
         };
         localStorage.setItem('calendarify-weekly-hours', JSON.stringify(weekly));
+        syncState();
       }
       closeTimeDropdown(btn);
     }
@@ -1148,6 +1154,7 @@
       let dayAvailability = JSON.parse(localStorage.getItem('calendarify-day-availability') || '{}');
       dayAvailability[day] = !isAvailable; // Toggle the state
       localStorage.setItem('calendarify-day-availability', JSON.stringify(dayAvailability));
+      syncState();
     }
 
     // --- Calendar Override System ---
@@ -3263,7 +3270,6 @@
       document.getElementById('global-search-results').classList.add('hidden');
     }
 
-    initAuth('dashboard-body', loadState);
 
     function updateGoogleCalendarButton() {
       const btn = document.getElementById('google-calendar-connect-btn');


### PR DESCRIPTION
## Summary
- trigger backend sync after changing availability settings so overrides, day and weekly hours persist

## Testing
- `yarn test` *(fails: Missing package: jest@virtual...)*

------
https://chatgpt.com/codex/tasks/task_e_68838cc591b483209e4a4b3d628fea2c