### PR TITLE
Fix dashboard auth init timing

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -99,19 +99,24 @@
     async function syncState() {
       const token = localStorage.getItem("calendarify-token");
       if (!token) return;
-      
+
       // Remove surrounding quotes if they exist
       const cleanToken = token.replace(/^"|"$/g, "");
-      
-      await fetch(`${API_URL}/users/me/state`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${cleanToken}`,
-        },
-        body: JSON.stringify(collectState()),
-      });
+
+      try {
+        await fetch(`${API_URL}/users/me/state`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${cleanToken}`,
+          },
+          body: JSON.stringify(collectState()),
+        });
+      } catch (e) {
+        console.error('syncState error', e);
+      }
     }
+
 
     const _setItem = localStorage.setItem.bind(localStorage);
     localStorage.setItem = function(k, v) {
@@ -400,6 +405,7 @@
       };
       
       localStorage.setItem('calendarify-overrides', JSON.stringify(calendarOverrides));
+      syncState();
       
       // Update calendar display
       renderCalendar();
@@ -420,6 +426,7 @@
       // Remove override from localStorage
       delete calendarOverrides[dateString];
       localStorage.setItem('calendarify-overrides', JSON.stringify(calendarOverrides));
+      syncState();
       
       // Update calendar display
       renderCalendar();
@@ -931,6 +938,11 @@
 
     // Initialize the dashboard
     document.addEventListener('DOMContentLoaded', async function() {
+
+      // Ensure we are authenticated and state is loaded before continuing
+      await initAuth('dashboard-body');
+      await loadState();
+
       updateClockFormatUI();
       updateAllCustomTimePickers();
       setupTimeInputListeners();
@@ -1035,6 +1047,7 @@
           end: inputs[1].value || inputs[1].placeholder,
         };
         localStorage.setItem('calendarify-weekly-hours', JSON.stringify(weekly));
+        syncState();
       }
       closeTimeDropdown(btn);
     }
@@ -1148,6 +1161,7 @@
       let dayAvailability = JSON.parse(localStorage.getItem('calendarify-day-availability') || '{}');
       dayAvailability[day] = !isAvailable; // Toggle the state
       localStorage.setItem('calendarify-day-availability', JSON.stringify(dayAvailability));
+      syncState();
     }
 
     // --- Calendar Override System ---
@@ -3263,7 +3277,6 @@
       document.getElementById('global-search-results').classList.add('hidden');
     }
 
-    initAuth('dashboard-body', loadState);
 
     function updateGoogleCalendarButton() {
       const btn = document.getElementById('google-calendar-connect-btn');

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -182,7 +182,7 @@
                   <div id="toggle-circle" class="w-6 h-6 bg-[#34D399] rounded-full absolute" style="top:1px; left:1px; transition:transform 0.3s, background-color 0.3s;"></div>
                 </button>
               </label>
-          </div>
+            </div>
           </div>
         </div>
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- wait for authentication and state load before initializing dashboard sections
- remove duplicate initAuth call

## Testing
- `npm test` *(fails: Missing package: jest@virtual...)*

------
https://chatgpt.com/codex/tasks/task_e_68838cc591b483209e4a4b3d628fea2c