### PR TITLE
Fix copy link without display name

### DIFF
--- a/dashboard/dashboard.css
+++ b/dashboard/dashboard.css
@@ -983,6 +983,11 @@
     .contact-menu.open {
       display: block;
     }
+
+    /* Limit event types section width when only one is shown */
+    #event-types-grid.limited-width {
+      max-width: 50%;
+    }
     
     /* Integration logos - keeping original appearance */
     #integrations-section .card img {

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -297,14 +297,26 @@
     // Utility functions
     function copyLink(slug) {
       const prefix = window.PREPEND_URL || window.FRONTEND_URL || window.location.origin;
-      const display = localStorage.getItem('calendarify-display-name') || 'user';
+      const display = localStorage.getItem('calendarify-display-name');
+
+      if (!display || display.trim() === '') {
+        showNotification('Please set a display name in your profile settings before sharing links');
+        return;
+      }
+
       navigator.clipboard.writeText(`${prefix}/booking/${encodeURIComponent(display)}/${slug}`);
       showNotification('Link copied to clipboard');
     }
 
     function openShareModal(title, slug) {
       const prefix = window.PREPEND_URL || window.FRONTEND_URL || window.location.origin;
-      const display = localStorage.getItem('calendarify-display-name') || 'user';
+      const display = localStorage.getItem('calendarify-display-name');
+
+      if (!display || display.trim() === '') {
+        showNotification('Please set a display name in your profile settings before sharing links');
+        return;
+      }
+
       const link = `${prefix}/booking/${encodeURIComponent(display)}/${slug}`;
       document.getElementById('share-modal-title').textContent = title;
       document.getElementById('share-modal-link').value = link;
@@ -1659,6 +1671,13 @@
     function renderEventTypes() {
       const eventTypesGrid = document.getElementById('event-types-grid');
       const eventTypes = JSON.parse(localStorage.getItem('calendarify-event-types') || '[]');
+
+      // Adjust grid width based on number of event types
+      if (eventTypes.length <= 1) {
+        eventTypesGrid.classList.add('limited-width');
+      } else {
+        eventTypesGrid.classList.remove('limited-width');
+      }
       
       // Start with the default event type
       let html = '';
@@ -1716,11 +1735,9 @@
                 ${eventType.description ? `<div class="text-[#A3B3AF] text-sm mt-1">${eventType.description}</div>` : ''}
                 ${tagsText}
               </div>
-              <button class="text-[#A3B3AF] hover:text-[#34D399]" title="Favorite"><span class="material-icons-outlined">star_border</span></button>
             </div>
             <div class="flex gap-2 mt-2">
               <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="copyLink('${eventType.slug}')"><span class="material-icons-outlined text-base">link</span>Copy link</button>
-              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="openShareModal('${eventType.name}','${eventType.slug}')"><span class="material-icons-outlined text-base">share</span>Share</button>
               <div class="relative">
                 <button class="text-[#A3B3AF] hover:text-[#34D399] px-2 py-1 rounded-full" onclick="toggleCardMenu(this)"><span class="material-icons-outlined">more_vert</span></button>
                 <div class="absolute right-0 mt-2 w-40 bg-[#1E3A34] rounded-lg shadow-lg py-2 z-50 hidden card-menu">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -109,31 +109,7 @@
             </button>
           </div>
         </div>
-        <div class="dashboard-grid" id="event-types-grid">
-          <div class="card flex flex-col gap-3">
-            <div class="flex items-center justify-between">
-              <div>
-                <h3 class="text-lg font-bold text-white">30-min Intro Call</h3>
-                <div class="text-[#A3B3AF] text-sm">1-on-1 • 30 min</div>
-            </div>
-              <button class="text-[#A3B3AF] hover:text-[#34D399]" title="Favorite"><span class="material-icons-outlined">star_border</span></button>
-          </div>
-            <div class="flex gap-2 mt-2">
-              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="copyLink('30-min-intro-call')"><span class="material-icons-outlined text-base">link</span>Copy link</button>
-              <button class="bg-[#19342e] text-[#34D399] px-3 py-1 rounded-lg flex items-center gap-1 text-sm" onclick="openShareModal('30-min Intro Call','30-min-intro-call')"><span class="material-icons-outlined text-base">share</span>Share</button>
-              <div class="relative">
-                <button class="text-[#A3B3AF] hover:text-[#34D399] px-2 py-1 rounded-full" onclick="toggleCardMenu(this)"><span class="material-icons-outlined">more_vert</span></button>
-                <div class="absolute right-0 mt-2 w-40 bg-[#1E3A34] rounded-lg shadow-lg py-2 z-50 hidden card-menu">
-                  <button class="block w-full text-left px-4 py-2 text-[#E0E0E0] hover:bg-[#19342e]">Edit</button>
-                  <button class="block w-full text-left px-4 py-2 text-[#E0E0E0] hover:bg-[#19342e]">Clone</button>
-                  <button class="block w-full text-left px-4 py-2 text-[#E0E0E0] hover:bg-[#19342e]">Add Note</button>
-                  <button class="block w-full text-left px-4 py-2 text-[#E0E0E0] hover:bg-[#19342e]">Mark Secret</button>
-                  <button class="block w-full text-left px-4 py-2 text-[#E0E0E0] hover:bg-[#19342e]" onclick="deleteEventType('${eventType.id}')">Delete</button>
-            </div>
-          </div>
-            </div>
-          </div>
-        </div>
+        <div class="dashboard-grid" id="event-types-grid"></div>
       </section>
 
       <!-- Meetings Section -->


### PR DESCRIPTION
## Summary
- show an error when no display name is set before copying links
- remove share button from event type cards
- remove favorite icon and fix width of Event Types section
- don't center Event Types grid and use half width only for single item

## Testing
- `yarn install` *(fails: Could not read from remote repository)*
- `yarn test` *(fails: package doesn't seem present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68849e1a487c8320a26f15a2b3b71922