### PR TITLE
Enforce host availability on booking page

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -25,6 +25,16 @@ function login(data) {
   return apiRequest('/auth/login', data);
 }
 
+function storeToken(token, persist) {
+  if (persist) {
+    localStorage.setItem('calendarify-token', token);
+    sessionStorage.removeItem('calendarify-token');
+  } else {
+    sessionStorage.setItem('calendarify-token', token);
+    localStorage.removeItem('calendarify-token');
+  }
+}
+
 async function loadUserState(token) {
   // Remove surrounding quotes if they exist
   const cleanToken = token.replace(/^"|"$/g, '');
@@ -72,7 +82,8 @@ document.addEventListener('DOMContentLoaded', () => {
         await register({ name, email, password });
         console.log('User registered, logging in...');
         const { access_token } = await login({ email, password });
-        localStorage.setItem('calendarify-token', access_token);
+        const remember = signupForm.querySelector('#signup-remember').checked;
+        storeToken(access_token, remember);
         await loadUserState(access_token);
         window.location.href = '/dashboard';
       } catch (e) {
@@ -91,7 +102,8 @@ document.addEventListener('DOMContentLoaded', () => {
       err.textContent = '';
       try {
         const { access_token } = await login({ email, password });
-        localStorage.setItem('calendarify-token', access_token);
+        const remember = loginForm.querySelector('#login-remember').checked;
+        storeToken(access_token, remember);
         await loadUserState(access_token);
         window.location.href = '/dashboard';
       } catch (e) {
@@ -102,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 async function verifyToken() {
-  const token = localStorage.getItem('calendarify-token');
+  const token = sessionStorage.getItem('calendarify-token') || localStorage.getItem('calendarify-token');
   if (!token) return false;
   
   // Remove surrounding quotes if they exist
@@ -120,6 +132,7 @@ async function verifyToken() {
     console.error('Token verification error:', error);
   }
   localStorage.removeItem('calendarify-token');
+  sessionStorage.removeItem('calendarify-token');
   return false;
 }
 
@@ -133,7 +146,7 @@ async function requireAuth() {
 }
 
 async function initAuth(bodyId, onSuccess) {
-  const t = localStorage.getItem('calendarify-token');
+  const t = sessionStorage.getItem('calendarify-token') || localStorage.getItem('calendarify-token');
   if (!t) {
     window.location.replace('/log-in');
     return;

--- a/backend/src/users/user-state.service.ts
+++ b/backend/src/users/user-state.service.ts
@@ -31,4 +31,10 @@ export class UserStateService {
       create: { user_id: userId, data },
     });
   }
+
+  async loadByDisplayName(displayName: string): Promise<any> {
+    const user = await this.prisma.user.findUnique({ where: { display_name: displayName } });
+    if (!user) return {};
+    return this.load(user.id);
+  }
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -24,6 +24,11 @@ export class UsersController {
     return this.users.findByDisplayName(name);
   }
 
+  @Get('display/:name/state')
+  stateByDisplay(@Param('name') name: string) {
+    return this.state.loadByDisplayName(name);
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get('me/state')
   getState(@Request() req) {

--- a/booking/index.html
+++ b/booking/index.html
@@ -317,7 +317,25 @@
                 }
             }
 
+            try {
+                const resState = await fetch(`${API_URL}/users/display/${display}/state`);
+                if (resState.ok) {
+                    const state = await resState.json();
+                    Object.entries(state).forEach(([k,v]) => {
+                        localStorage.setItem(k, JSON.stringify(v));
+                    });
+                }
+            } catch (e) {
+                console.error('Failed to refresh host state', e);
+            }
+
+
             document.getElementById('eventTitle').textContent = `Book: ${event.title}`;
+
+            const eventDuration = parseInt(event.duration) || 30;
+            const bufferBefore = parseInt(event.bufferBefore) || 0;
+            const bufferAfter = parseInt(event.bufferAfter) || 0;
+            const advanceNotice = parseInt(event.advanceNotice) || 0;
             
             let currentDate = new Date();
             let selectedDate = null; // No initial selection
@@ -348,21 +366,43 @@
                 return { h, m };
             }
 
-            function generateSlotsInRange(startStr, endStr) {
+            function generateSlotsInRange(startStr, endStr, date) {
                 const { h: startH, m: startM } = parseTime(startStr);
                 const { h: endH, m: endM } = parseTime(endStr);
+
+                const dayStart = startH * 60 + startM;
+                const dayEnd = endH * 60 + endM;
+
+                const effStart = dayStart + bufferBefore;
+                const effEnd = dayEnd - bufferAfter - eventDuration;
+                if (effEnd < effStart) return [];
+
+                const step = 15;
+                let currentMinutes = effStart;
                 const slots = [];
-                let current = new Date();
-                current.setHours(startH, startM, 0, 0);
-                const end = new Date();
-                end.setHours(endH, endM, 0, 0);
-                while (current < end) {
-                    slots.push(current.toLocaleTimeString('en-US', {
+                while (currentMinutes <= effEnd) {
+                    const slot = new Date(date);
+                    slot.setHours(Math.floor(currentMinutes / 60), currentMinutes % 60, 0, 0);
+
+                    if (advanceNotice) {
+                        const earliest = new Date(Date.now() + advanceNotice * 60000);
+                        if (slot < earliest) {
+                            currentMinutes += step;
+                            continue;
+                        }
+                    } else if (date.toDateString() === new Date().toDateString()) {
+                        if (slot <= new Date()) {
+                            currentMinutes += step;
+                            continue;
+                        }
+                    }
+
+                    slots.push(slot.toLocaleTimeString('en-US', {
                         hour: 'numeric',
                         minute: '2-digit',
                         hour12: true
                     }));
-                    current.setMinutes(current.getMinutes() + 15);
+                    currentMinutes += step;
                 }
                 return slots;
             }
@@ -378,7 +418,7 @@
                     if (override.timeSlots && override.timeSlots.length > 0) {
                         let list = [];
                         override.timeSlots.forEach(t => {
-                            list = list.concat(generateSlotsInRange(t.start, t.end));
+                            list = list.concat(generateSlotsInRange(t.start, t.end, date));
                         });
                         return list;
                     }
@@ -386,7 +426,7 @@
 
                 const weekly = JSON.parse(localStorage.getItem('calendarify-weekly-hours') || '{}');
                 const range = weekly[dayKey] || { start: '09:00 AM', end: '17:00 PM' };
-                return generateSlotsInRange(range.start, range.end);
+                return generateSlotsInRange(range.start, range.end, date);
             }
 
             function updateTimeSlots() {
@@ -417,18 +457,6 @@
                     confirmButton.style.pointerEvents = 'none';
                 } else {
                     let timeSlots = generateTimeSlots(selectedDate);
-                    if (selectedDate.toDateString() === new Date().toDateString()) {
-                        const now = new Date();
-                        timeSlots = timeSlots.filter(t => {
-                            const [time, ap] = t.split(' ');
-                            let [h,m] = time.split(':').map(Number);
-                            if (ap === 'PM' && h !== 12) h += 12;
-                            if (ap === 'AM' && h === 12) h = 0;
-                            const slot = new Date(selectedDate);
-                            slot.setHours(h, m, 0, 0);
-                            return slot > now;
-                        });
-                    }
 
                     if (timeSlots.length === 0) {
                         container.innerHTML = '<p class="text-center text-gray-500">No availability</p>';

--- a/log-in/index.html
+++ b/log-in/index.html
@@ -70,6 +70,10 @@
                   />
                 </label>
               </div>
+              <div class="flex items-center px-4 py-2 mx-auto space-x-2">
+                <input id="login-remember" type="checkbox" class="rounded" />
+                <label for="login-remember" class="text-sm text-[#9eb7a8]">Stay logged in</label>
+              </div>
               <div class="flex px-4 py-3 mx-auto">
                 <button
                   type="submit"

--- a/sign-up/index.html
+++ b/sign-up/index.html
@@ -93,6 +93,10 @@
                   />
                 </label>
               </div>
+              <div class="flex items-center px-4 py-2 mx-auto space-x-2">
+                <input id="signup-remember" type="checkbox" class="rounded" />
+                <label for="signup-remember" class="text-sm text-[#9eb7a8]">Stay logged in</label>
+              </div>
               <div class="flex px-4 py-3 mx-auto">
                 <button
                   type="submit"


### PR DESCRIPTION
## Summary
- update booking pages to refresh host availability from backend
- add persistent login option on sign-up and log-in pages
- store auth tokens in sessionStorage unless "Stay logged in" is checked
- expose public endpoint to read host state

## Testing
- `yarn install` *(fails: Could not read from remote repository)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6884b01f78c8832086282c46bd1bd8e0