### PR TITLE
Add booking persistence and slot blocking

### DIFF
--- a/booking/index.html
+++ b/booking/index.html
@@ -516,13 +516,32 @@
                         }
                     }
 
-                    const timeStr = slot.toLocaleTimeString('en-US', {
-                        hour: 'numeric',
-                        minute: '2-digit',
-                        hour12: true
+                    // Exclude times that have already been booked (respect buffer)
+                    let booked = {};
+                    try {
+                        booked = JSON.parse(localStorage.getItem('calendarify-booked-slots') || '{}');
+                    } catch {}
+                    const busy = booked[event.slug] || [];
+                    const candidateStart = new Date(slot.getTime() - bufferBefore * 60000);
+                    const candidateEnd = new Date(slot.getTime() + eventDuration * 60000 + bufferAfter * 60000);
+                    const conflict = busy.some(b => {
+                        const bStart = new Date(b.start);
+                        const bEnd = new Date(b.end);
+                        const bStartBuf = new Date(bStart.getTime() - (b.bufferBefore || 0) * 60000);
+                        const bEndBuf = new Date(bEnd.getTime() + (b.bufferAfter || 0) * 60000);
+                        return candidateStart < bEndBuf && candidateEnd > bStartBuf;
                     });
-                    slots.push(timeStr);
-                    console.log('[TEMP-DEBUG] Added slot', timeStr);
+                    if (!conflict) {
+                        const timeStr = slot.toLocaleTimeString('en-US', {
+                            hour: 'numeric',
+                            minute: '2-digit',
+                            hour12: true
+                        });
+                        slots.push(timeStr);
+                        console.log('[TEMP-DEBUG] Added slot', timeStr);
+                    } else {
+                        console.log('[TEMP-DEBUG] Skipping booked slot at', slot);
+                    }
                     currentMinutes += step;
                 }
                 
@@ -836,7 +855,7 @@
 
             function confirmBooking() {
                 if (!validateBookingForm()) return;
-                
+
                 // Collect form data
                 const bookingData = {
                     eventTitle: event.title || event.name,
@@ -858,6 +877,45 @@
                         bookingData.questions.push({ question: questionObj.text, answer });
                     });
                 }
+
+                // Persist meeting to localStorage so host dashboard can display it
+                const meeting = {
+                    id: Date.now(),
+                    invitee: bookingData.name || 'Anonymous',
+                    email: bookingData.email || '',
+                    eventType: bookingData.eventTitle,
+                    date: `${bookingData.date}, ${bookingData.time}`,
+                    status: 'Confirmed',
+                    slug: event.slug
+                };
+
+                let meetingsObj;
+                try {
+                    meetingsObj = JSON.parse(localStorage.getItem('calendarify-meetings') || '{}');
+                } catch {
+                    meetingsObj = {};
+                }
+                if (!meetingsObj.upcoming) meetingsObj = { upcoming: [], past: [], pending: [] };
+                meetingsObj.upcoming.push(meeting);
+                localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsObj));
+
+                // Mark this slot as booked so it becomes unavailable
+                const startDate = new Date(selectedDate);
+                const { h, m } = parseTime(selectedTime);
+                startDate.setHours(h, m, 0, 0);
+                const endDate = new Date(startDate.getTime() + eventDuration * 60000);
+                let booked = {};
+                try {
+                    booked = JSON.parse(localStorage.getItem('calendarify-booked-slots') || '{}');
+                } catch {}
+                if (!booked[event.slug]) booked[event.slug] = [];
+                booked[event.slug].push({
+                    start: startDate.toISOString(),
+                    end: endDate.toISOString(),
+                    bufferBefore,
+                    bufferAfter
+                });
+                localStorage.setItem('calendarify-booked-slots', JSON.stringify(booked));
 
                 console.log('Booking confirmed:', bookingData);
                 alert(`Booking confirmed for ${bookingData.date} at ${bookingData.time}!`);

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -202,7 +202,14 @@
         console.error('Could not find tbody element!');
         return;
       }
-      
+      // Reload meetings data from localStorage each time to reflect new bookings
+      try {
+        const stored = JSON.parse(localStorage.getItem('calendarify-meetings') || '{}');
+        if (stored.upcoming) {
+          meetingsData = stored;
+        }
+      } catch {}
+
       const meetings = getMeetingsData(tab);
       console.log('Meetings for tab', tab, ':', meetings);
       
@@ -259,19 +266,27 @@
     }
 
     // Store meetings data in a variable that can be modified
-    let meetingsData = {
-      upcoming: [
-        { id: 1, invitee: 'Jane Doe', email: 'jane@example.com', eventType: '30-min Intro Call', date: 'Today, 2:00 PM', status: 'Confirmed' }
-      ],
-      past: [
-        { id: 3, invitee: 'Alice Johnson', email: 'alice@test.com', eventType: '30-min Intro Call', date: 'Yesterday, 3:00 PM', status: 'Completed' }
-      ],
-      pending: [
-        { id: 2, invitee: 'John Smith', email: 'john@company.com', eventType: '1-hour Consultation', date: 'Tomorrow, 10:00 AM', status: 'Pending' }
-      ]
-    };
-    // Persist default meetings to localStorage if not present
-    if (!localStorage.getItem('calendarify-meetings')) {
+    let meetingsData = { upcoming: [], past: [], pending: [] };
+    try {
+      const storedMeetings = JSON.parse(localStorage.getItem('calendarify-meetings') || '{}');
+      if (storedMeetings.upcoming) {
+        meetingsData = storedMeetings;
+      } else {
+        // seed with example data if nothing stored yet
+        meetingsData = {
+          upcoming: [
+            { id: 1, invitee: 'Jane Doe', email: 'jane@example.com', eventType: '30-min Intro Call', date: 'Today, 2:00 PM', status: 'Confirmed' }
+          ],
+          past: [
+            { id: 3, invitee: 'Alice Johnson', email: 'alice@test.com', eventType: '30-min Intro Call', date: 'Yesterday, 3:00 PM', status: 'Completed' }
+          ],
+          pending: [
+            { id: 2, invitee: 'John Smith', email: 'john@company.com', eventType: '1-hour Consultation', date: 'Tomorrow, 10:00 AM', status: 'Pending' }
+          ]
+        };
+        localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
+      }
+    } catch {
       localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
     }
 
@@ -3178,6 +3193,9 @@
         // Then remove meeting from data (cancelled meetings are removed)
         removeMeetingFromData(meetingInfo.id);
         console.log('Meeting removed from data. Current data:', meetingsData);
+
+        // Persist updated meetings to localStorage
+        localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
         
         // Show notification
         showNotification(`Meeting with ${meetingInfo.invitee} has been cancelled`);
@@ -3215,6 +3233,9 @@
         // Then remove meeting from data
         removeMeetingFromData(meetingInfo.id);
         console.log('Meeting removed from data. Current data:', meetingsData);
+
+        // Persist updated meetings to localStorage
+        localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
         
         // Show notification
         showNotification(`Meeting with ${meetingInfo.invitee} has been deleted`);


### PR DESCRIPTION
## Summary
- persist scheduled bookings to localStorage so hosts can see them in the dashboard
- block booked timeslots from being selectable on the booking page
- load meetings from storage when opening the meetings tab
- persist meeting removals to storage

## Testing
- `yarn test` *(fails: Repository URL unreachable during yarn install)*

------
https://chatgpt.com/codex/tasks/task_e_6888dff501e4832082fa822d372ac411