### PR TITLE
Add booking persistence and database-backed slots

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -34,6 +34,9 @@ model EventType {
   title       String
   description String?
   duration    Int
+  buffer_before Int @default(0)
+  buffer_after  Int @default(0)
+  advance_notice Int @default(0)
   created_at  DateTime @default(now())
   updated_at  DateTime @updatedAt
   bookings    Booking[]

--- a/backend/src/bookings/bookings.controller.ts
+++ b/backend/src/bookings/bookings.controller.ts
@@ -1,9 +1,26 @@
-import { Controller, Delete, Param } from '@nestjs/common';
+import { Controller, Delete, Param, Get, UseGuards, Request, Patch, Body } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { BookingsService } from './bookings.service';
 
 @Controller('bookings')
 export class BookingsController {
+  constructor(private bookings: BookingsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  list(@Request() req) {
+    return this.bookings.findForUser(req.user.userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return { id };
+    return this.bookings.remove(id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() body: any) {
+    return this.bookings.update(id, body);
   }
 }

--- a/backend/src/bookings/bookings.module.ts
+++ b/backend/src/bookings/bookings.module.ts
@@ -1,7 +1,11 @@
 import { Module } from '@nestjs/common';
 import { BookingsController } from './bookings.controller';
+import { BookingsService } from './bookings.service';
+import { PrismaService } from '../prisma.service';
 
 @Module({
   controllers: [BookingsController],
+  providers: [BookingsService, PrismaService],
+  exports: [BookingsService],
 })
 export class BookingsModule {}

--- a/backend/src/bookings/bookings.service.ts
+++ b/backend/src/bookings/bookings.service.ts
@@ -1,4 +1,43 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+interface CreateBookingDto {
+  event_type_id: string;
+  user_id: string;
+  name: string;
+  email: string;
+  starts_at: Date;
+  ends_at: Date;
+}
 
 @Injectable()
-export class BookingsService {}
+export class BookingsService {
+  constructor(private prisma: PrismaService) {}
+
+  create(data: CreateBookingDto) {
+    return this.prisma.booking.create({ data });
+  }
+
+  findForUser(userId: string) {
+    return this.prisma.booking.findMany({
+      where: { user_id: userId },
+      include: { event_type: true },
+      orderBy: { starts_at: 'asc' },
+    });
+  }
+
+  remove(id: string) {
+    return this.prisma.booking.delete({ where: { id } });
+  }
+
+  update(id: string, data: { start: string; end: string }) {
+    return this.prisma.booking.update({
+      where: { id },
+      data: {
+        starts_at: new Date(data.start),
+        ends_at: new Date(data.end),
+      },
+      include: { event_type: true },
+    });
+  }
+}

--- a/backend/src/event-types/event-types.controller.ts
+++ b/backend/src/event-types/event-types.controller.ts
@@ -42,12 +42,17 @@ export class EventTypesController {
   }
 
   @Get(':slug/slots')
-  slots(@Param('slug') slug: string, @Query() query: any) {
-    return { slug, query };
+  async slots(
+    @Param('slug') slug: string,
+    @Query('date') date: string,
+    @Query('exclude') exclude?: string,
+  ) {
+    const d = date ? new Date(date) : new Date();
+    return this.events.availableSlots(slug, d, exclude);
   }
 
   @Post(':slug/bookings')
-  book(@Param('slug') slug: string, @Body() body: any) {
-    return { slug, data: body };
+  async book(@Param('slug') slug: string, @Body() body: any) {
+    return this.events.book(slug, body);
   }
 }

--- a/backend/src/event-types/event-types.service.ts
+++ b/backend/src/event-types/event-types.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { generateUniqueSlug } from './slug.utils';
+import { generateSlots } from './slot.utils';
 
 export interface EventType {
   id: string;
@@ -9,6 +10,9 @@ export interface EventType {
   title: string;
   description?: string;
   duration: number;
+  buffer_before?: number;
+  buffer_after?: number;
+  advance_notice?: number;
 }
 
 @Injectable()
@@ -22,7 +26,14 @@ export class EventTypesService {
   async create(userId: string, data: Omit<EventType, 'id' | 'userId'>) {
     const slug = await generateUniqueSlug(this.prisma, data.slug || data.title);
     return this.prisma.eventType.create({
-      data: { user_id: userId, ...data, slug },
+      data: {
+        user_id: userId,
+        ...data,
+        buffer_before: data.buffer_before ?? 0,
+        buffer_after: data.buffer_after ?? 0,
+        advance_notice: data.advance_notice ?? 0,
+        slug,
+      },
     });
   }
 
@@ -44,5 +55,62 @@ export class EventTypesService {
 
   remove(id: string) {
     return this.prisma.eventType.delete({ where: { id } });
+  }
+
+  async availableSlots(slug: string, date: Date, exclude?: string) {
+    const et = await this.prisma.eventType.findUnique({ where: { slug } });
+    if (!et) return [];
+
+    const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0));
+    const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59));
+
+    const bookings = await this.prisma.booking.findMany({
+      where: {
+        event_type_id: et.id,
+        starts_at: { gte: start },
+        ends_at: { lte: end },
+        ...(exclude ? { NOT: { id: exclude } } : {}),
+      },
+    });
+
+    const busy = bookings.map(b => ({
+      start: new Date(b.starts_at.getTime() - et.buffer_before * 60000),
+      end: new Date(b.ends_at.getTime() + et.buffer_after * 60000),
+    }));
+
+    const dayRule = {
+      dayOfWeek: start.getUTCDay(),
+      startMinute: 9 * 60,
+      endMinute: 17 * 60 - et.duration,
+    };
+
+    let slots = generateSlots({
+      from: start,
+      to: end,
+      duration: et.duration,
+      timezone: 'UTC',
+      rules: [dayRule],
+      overrides: [],
+      busy,
+    });
+
+    const earliest = new Date(Date.now() + et.advance_notice * 60000);
+    slots = slots.filter(s => new Date(s) >= earliest);
+    return slots;
+  }
+
+  async book(slug: string, data: { name: string; email: string; start: string; end: string }) {
+    const et = await this.prisma.eventType.findUnique({ where: { slug } });
+    if (!et) throw new Error('event type not found');
+    return this.prisma.booking.create({
+      data: {
+        event_type_id: et.id,
+        user_id: et.user_id,
+        name: data.name,
+        email: data.email,
+        starts_at: new Date(data.start),
+        ends_at: new Date(data.end),
+      },
+    });
   }
 }

--- a/booking/index.html
+++ b/booking/index.html
@@ -516,13 +516,32 @@
                         }
                     }
 
-                    const timeStr = slot.toLocaleTimeString('en-US', {
-                        hour: 'numeric',
-                        minute: '2-digit',
-                        hour12: true
+                    // Exclude times that have already been booked (respect buffer)
+                    let booked = {};
+                    try {
+                        booked = JSON.parse(localStorage.getItem('calendarify-booked-slots') || '{}');
+                    } catch {}
+                    const busy = booked[event.slug] || [];
+                    const candidateStart = new Date(slot.getTime() - bufferBefore * 60000);
+                    const candidateEnd = new Date(slot.getTime() + eventDuration * 60000 + bufferAfter * 60000);
+                    const conflict = busy.some(b => {
+                        const bStart = new Date(b.start);
+                        const bEnd = new Date(b.end);
+                        const bStartBuf = new Date(bStart.getTime() - (b.bufferBefore || 0) * 60000);
+                        const bEndBuf = new Date(bEnd.getTime() + (b.bufferAfter || 0) * 60000);
+                        return candidateStart < bEndBuf && candidateEnd > bStartBuf;
                     });
-                    slots.push(timeStr);
-                    console.log('[TEMP-DEBUG] Added slot', timeStr);
+                    if (!conflict) {
+                        const timeStr = slot.toLocaleTimeString('en-US', {
+                            hour: 'numeric',
+                            minute: '2-digit',
+                            hour12: true
+                        });
+                        slots.push(timeStr);
+                        console.log('[TEMP-DEBUG] Added slot', timeStr);
+                    } else {
+                        console.log('[TEMP-DEBUG] Skipping booked slot at', slot);
+                    }
                     currentMinutes += step;
                 }
                 
@@ -530,7 +549,15 @@
                 return slots;
             }
 
-            function generateTimeSlots(date) {
+            async function generateTimeSlots(date) {
+                try {
+                    const res = await fetch(`${API_URL}/event-types/${event.slug}/slots?date=${date.toISOString().split('T')[0]}`);
+                    if (res.ok) {
+                        const data = await res.json();
+                        return data.map(iso => formatTime(iso.substring(11,16)));
+                    }
+                } catch (e) { console.log('slot fetch failed', e); }
+
                 const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
                 const dayKey = dayNames[date.getDay()];
 
@@ -557,7 +584,7 @@
                 return generateSlotsInRange(range.start, range.end, date);
             }
 
-            function updateTimeSlots() {
+            async function updateTimeSlots() {
                 console.log('[TEMP-DEBUG] updateTimeSlots for', selectedDate);
                 const container = document.getElementById('timeSlotsContainer');
                 const dateHeader = document.getElementById('selectedDate');
@@ -596,7 +623,7 @@
                     confirmButton.style.opacity = '0.5';
                     confirmButton.style.pointerEvents = 'none';
                 } else {
-                    let timeSlots = generateTimeSlots(selectedDate);
+                    let timeSlots = await generateTimeSlots(selectedDate);
                     console.log('[TEMP-DEBUG] Generated slots', timeSlots);
 
                     if (timeSlots.length === 0) {
@@ -834,9 +861,9 @@
                 return true;
             }
 
-            function confirmBooking() {
+            async function confirmBooking() {
                 if (!validateBookingForm()) return;
-                
+
                 // Collect form data
                 const bookingData = {
                     eventTitle: event.title || event.name,
@@ -858,6 +885,64 @@
                         bookingData.questions.push({ question: questionObj.text, answer });
                     });
                 }
+
+                const startDate = new Date(selectedDate);
+                const { h, m } = parseTime(selectedTime);
+                startDate.setHours(h, m, 0, 0);
+                const endDate = new Date(startDate.getTime() + eventDuration * 60000);
+
+                // Persist meeting to server
+                try {
+                    const res = await fetch(`${API_URL}/event-types/${event.slug}/bookings`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            name: bookingData.name,
+                            email: bookingData.email,
+                            start: startDate.toISOString(),
+                            end: endDate.toISOString()
+                        })
+                    });
+                    console.log('Server booking response', res.status);
+                } catch (e) { console.error('Booking API failed', e); }
+
+                // Persist meeting to localStorage so host dashboard can display it
+                const meeting = {
+                    id: Date.now(),
+                    invitee: bookingData.name || 'Anonymous',
+                    email: bookingData.email || '',
+                    eventType: bookingData.eventTitle,
+                    slug: event.slug,
+                    duration: eventDuration,
+                    start: startDate.toISOString(),
+                    end: endDate.toISOString(),
+                    date: `${bookingData.date}, ${bookingData.time}`,
+                    status: 'Confirmed'
+                };
+
+                let meetingsObj;
+                try {
+                    meetingsObj = JSON.parse(localStorage.getItem('calendarify-meetings') || '{}');
+                } catch {
+                    meetingsObj = {};
+                }
+                if (!meetingsObj.upcoming) meetingsObj = { upcoming: [], past: [], pending: [] };
+                meetingsObj.upcoming.push(meeting);
+                localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsObj));
+
+                // Mark this slot as booked so it becomes unavailable
+                let booked = {};
+                try {
+                    booked = JSON.parse(localStorage.getItem('calendarify-booked-slots') || '{}');
+                } catch {}
+                if (!booked[event.slug]) booked[event.slug] = [];
+                booked[event.slug].push({
+                    start: startDate.toISOString(),
+                    end: endDate.toISOString(),
+                    bufferBefore,
+                    bufferAfter
+                });
+                localStorage.setItem('calendarify-booked-slots', JSON.stringify(booked));
 
                 console.log('Booking confirmed:', bookingData);
                 alert(`Booking confirmed for ${bookingData.date} at ${bookingData.time}!`);

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -91,6 +91,35 @@
       return [];
     }
 
+    async function fetchMeetingsFromServer() {
+      const token = getAnyToken();
+      if (!token) return;
+      const clean = token.replace(/^"|"$/g, '');
+      const res = await fetch(`${API_URL}/bookings`, { headers: { Authorization: `Bearer ${clean}` } });
+      if (res.ok) {
+        const data = await res.json();
+        meetingsData = { upcoming: [], past: [], pending: [] };
+        const now = new Date();
+        data.forEach(b => {
+          const start = new Date(b.starts_at);
+          const info = {
+            id: b.id,
+            invitee: b.name,
+            email: b.email,
+            eventType: b.event_type.title,
+            slug: b.event_type.slug,
+            duration: b.event_type.duration,
+            start: b.starts_at,
+            end: b.ends_at,
+            date: new Date(b.starts_at).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }),
+            status: 'Confirmed'
+          };
+          if (start < now) meetingsData.past.push(info); else meetingsData.upcoming.push(info);
+        });
+        localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
+      }
+    }
+
     function collectState() {
       const data = {};
       for (let i = 0; i < localStorage.length; i++) {
@@ -168,7 +197,7 @@
     }
 
     // Meetings tab functionality
-    function showMeetingsTab(tab, btn) {
+    async function showMeetingsTab(tab, btn) {
       console.log('showMeetingsTab called with tab:', tab);
       
       // Save current tab to localStorage
@@ -189,6 +218,7 @@
         console.log('Active button classes:', btn.className);
       }
 
+      await fetchMeetingsFromServer();
       // Update table content based on tab
       updateMeetingsTable(tab);
     }
@@ -202,7 +232,14 @@
         console.error('Could not find tbody element!');
         return;
       }
-      
+      // Reload meetings data from localStorage each time to reflect new bookings
+      try {
+        const stored = JSON.parse(localStorage.getItem('calendarify-meetings') || '{}');
+        if (stored.upcoming) {
+          meetingsData = stored;
+        }
+      } catch {}
+
       const meetings = getMeetingsData(tab);
       console.log('Meetings for tab', tab, ':', meetings);
       
@@ -259,19 +296,27 @@
     }
 
     // Store meetings data in a variable that can be modified
-    let meetingsData = {
-      upcoming: [
-        { id: 1, invitee: 'Jane Doe', email: 'jane@example.com', eventType: '30-min Intro Call', date: 'Today, 2:00 PM', status: 'Confirmed' }
-      ],
-      past: [
-        { id: 3, invitee: 'Alice Johnson', email: 'alice@test.com', eventType: '30-min Intro Call', date: 'Yesterday, 3:00 PM', status: 'Completed' }
-      ],
-      pending: [
-        { id: 2, invitee: 'John Smith', email: 'john@company.com', eventType: '1-hour Consultation', date: 'Tomorrow, 10:00 AM', status: 'Pending' }
-      ]
-    };
-    // Persist default meetings to localStorage if not present
-    if (!localStorage.getItem('calendarify-meetings')) {
+    let meetingsData = { upcoming: [], past: [], pending: [] };
+    try {
+      const storedMeetings = JSON.parse(localStorage.getItem('calendarify-meetings') || '{}');
+      if (storedMeetings.upcoming) {
+        meetingsData = storedMeetings;
+      } else {
+        // seed with example data if nothing stored yet
+        meetingsData = {
+          upcoming: [
+            { id: 1, invitee: 'Jane Doe', email: 'jane@example.com', eventType: '30-min Intro Call', date: 'Today, 2:00 PM', status: 'Confirmed' }
+          ],
+          past: [
+            { id: 3, invitee: 'Alice Johnson', email: 'alice@test.com', eventType: '30-min Intro Call', date: 'Yesterday, 3:00 PM', status: 'Completed' }
+          ],
+          pending: [
+            { id: 2, invitee: 'John Smith', email: 'john@company.com', eventType: '1-hour Consultation', date: 'Tomorrow, 10:00 AM', status: 'Pending' }
+          ]
+        };
+        localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
+      }
+    } catch {
       localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
     }
 
@@ -807,7 +852,7 @@
       
       // Otherwise, close all modals as usual
       document.querySelectorAll('.hidden').forEach(el => {
-        if (el.id === 'modal-backdrop' || el.id === 'share-modal' || el.id === 'delete-event-type-confirm-modal' || el.id === 'cancel-meeting-confirm-modal' || el.id === 'delete-meeting-confirm-modal' || el.id === 'add-contact-modal' || el.id === 'delete-workflow-confirm-modal' || el.id === 'delete-contact-confirm-modal' || el.id === 'event-types-modal' || el.id === 'create-tag-modal' || el.id === 'tags-modal' || el.id === 'profile-modal' || el.id === 'change-displayname-modal') {
+        if (el.id === 'modal-backdrop' || el.id === 'share-modal' || el.id === 'delete-event-type-confirm-modal' || el.id === 'cancel-meeting-confirm-modal' || el.id === 'delete-meeting-confirm-modal' || el.id === 'add-contact-modal' || el.id === 'delete-workflow-confirm-modal' || el.id === 'delete-contact-confirm-modal' || el.id === 'event-types-modal' || el.id === 'create-tag-modal' || el.id === 'tags-modal' || el.id === 'profile-modal' || el.id === 'change-displayname-modal' || el.id === 'reschedule-modal') {
           el.classList.add('hidden');
         }
       });
@@ -817,6 +862,7 @@
       // Clear any stored data
       window.meetingToCancel = null;
       window.meetingToDelete = null;
+      window.meetingToReschedule = null;
       window.workflowToDelete = null;
       window.contactToDelete = null;
       window.tagToDelete = null;
@@ -3079,12 +3125,17 @@
 
     function rescheduleMeeting(meetingId) {
       const id = typeof meetingId === 'string' ? parseInt(meetingId) : meetingId;
-      const meeting = getMeetingsData('upcoming').find(m => m.id === id) || 
+      const meeting = getMeetingsData('upcoming').find(m => m.id === id) ||
                      getMeetingsData('pending').find(m => m.id === id);
-      
+
       if (meeting) {
-        showNotification(`Opening reschedule dialog for ${meeting.invitee}`);
-        // Here you would typically open a reschedule modal
+        window.meetingToReschedule = meeting;
+        const start = new Date(meeting.start);
+        const dateInput = document.getElementById('reschedule-date');
+        dateInput.value = start.toISOString().split('T')[0];
+        document.getElementById('modal-backdrop').classList.remove('hidden');
+        document.getElementById('reschedule-modal').classList.remove('hidden');
+        loadRescheduleSlots();
       } else {
         showNotification('Cannot reschedule past meetings');
       }
@@ -3178,6 +3229,9 @@
         // Then remove meeting from data (cancelled meetings are removed)
         removeMeetingFromData(meetingInfo.id);
         console.log('Meeting removed from data. Current data:', meetingsData);
+
+        // Persist updated meetings to localStorage
+        localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
         
         // Show notification
         showNotification(`Meeting with ${meetingInfo.invitee} has been cancelled`);
@@ -3215,6 +3269,9 @@
         // Then remove meeting from data
         removeMeetingFromData(meetingInfo.id);
         console.log('Meeting removed from data. Current data:', meetingsData);
+
+        // Persist updated meetings to localStorage
+        localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
         
         // Show notification
         showNotification(`Meeting with ${meetingInfo.invitee} has been deleted`);
@@ -3239,6 +3296,62 @@
       document.getElementById('delete-meeting-confirm-modal').classList.add('hidden');
       window.meetingToDelete = null;
     }
+
+    function closeRescheduleModal() {
+      document.getElementById('modal-backdrop').classList.add('hidden');
+      document.getElementById('reschedule-modal').classList.add('hidden');
+      window.meetingToReschedule = null;
+    }
+
+    async function loadRescheduleSlots() {
+      const meeting = window.meetingToReschedule;
+      if (!meeting) return;
+      const dateStr = document.getElementById('reschedule-date').value;
+      const res = await fetch(`${API_URL}/event-types/${meeting.slug}/slots?date=${dateStr}&exclude=${meeting.id}`);
+      const select = document.getElementById('reschedule-time');
+      select.innerHTML = '';
+      if (res.ok) {
+        const slots = await res.json();
+        slots.forEach(iso => {
+          const d = new Date(iso);
+          const display = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+          const opt = document.createElement('option');
+          opt.value = iso;
+          opt.textContent = display;
+          select.appendChild(opt);
+        });
+      }
+    }
+
+    async function confirmReschedule() {
+      const meeting = window.meetingToReschedule;
+      if (!meeting) return;
+      const iso = document.getElementById('reschedule-time').value;
+      if (!iso) {
+        showNotification('Please select a new time');
+        return;
+      }
+      const start = new Date(iso);
+      const end = new Date(start.getTime() + meeting.duration * 60000);
+      const token = getAnyToken();
+      const clean = token ? token.replace(/^"|"$/g, '') : '';
+      await fetch(`${API_URL}/bookings/${meeting.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${clean}` },
+        body: JSON.stringify({ start: start.toISOString(), end: end.toISOString() })
+      });
+      meeting.start = start.toISOString();
+      meeting.end = end.toISOString();
+      meeting.date = start.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+      localStorage.setItem('calendarify-meetings', JSON.stringify(meetingsData));
+      showNotification(`Meeting with ${meeting.invitee} rescheduled`);
+      closeRescheduleModal();
+      const activeTabButton = document.querySelector('#meetings-section button.active-tab');
+      const currentTab = activeTabButton ? activeTabButton.getAttribute('data-tab') : 'upcoming';
+      updateMeetingsTable(currentTab);
+    }
+
+    document.getElementById('reschedule-date').addEventListener('change', loadRescheduleSlots);
 
     // Test function to verify everything is working
     function testMeetingsFunctionality() {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -792,6 +792,28 @@
     </div>
   </div>
 
+  <!-- Reschedule Meeting Modal -->
+  <div id="reschedule-modal" class="fixed inset-0 z-50 hidden">
+    <div class="flex items-center justify-center min-h-screen p-4">
+      <div class="bg-[#1E3A34] rounded-xl shadow-2xl w-full max-w-sm">
+        <div class="flex items-center justify-between p-6 border-b border-[#2C4A43]">
+          <h2 class="text-xl font-bold text-white">Reschedule Meeting</h2>
+          <button onclick="closeRescheduleModal()" class="text-[#A3B3AF] hover:text-white transition-colors">
+            <span class="material-icons-outlined text-2xl">close</span>
+          </button>
+        </div>
+        <div class="p-6 space-y-4">
+          <input type="date" id="reschedule-date" class="w-full bg-[#19342e] border border-[#2C4A43] text-[#E0E0E0] rounded-lg px-4 py-3 focus:border-[#34D399] focus:ring-2 focus:ring-[#34D399]">
+          <select id="reschedule-time" class="w-full bg-[#19342e] border border-[#2C4A43] text-[#E0E0E0] rounded-lg px-4 py-3 focus:border-[#34D399] focus:ring-2 focus:ring-[#34D399]"></select>
+        </div>
+        <div class="flex items-center justify-end gap-3 p-6 border-t border-[#2C4A43]">
+          <button onclick="closeRescheduleModal()" class="px-6 py-3 text-[#A3B3AF] hover:text-white transition-colors font-medium">Cancel</button>
+          <button onclick="confirmReschedule()" class="bg-[#34D399] text-[#1A2E29] px-6 py-3 rounded-lg hover:bg-[#2C4A43] transition-colors font-bold">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Add Contact Modal -->
   <div id="add-contact-modal" class="fixed inset-0 z-50 hidden">
     <div class="flex items-center justify-center min-h-screen p-4">


### PR DESCRIPTION
## Summary
- extend `EventType` with buffer and advance notice fields
- implement booking creation and listing with Prisma
- compute available slots server-side and consume via API
- persist bookings to server when guests confirm
- load meetings from backend in the dashboard
- allow hosts to reschedule meetings from dashboard

## Testing
- `npm test` *(fails: package not in lockfile because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6888dff501e4832082fa822d372ac411