### PR TITLE
Fix buffer check in slot generator

### DIFF
--- a/backend/src/event-types/slot.utils.ts
+++ b/backend/src/event-types/slot.utils.ts
@@ -66,7 +66,7 @@ export function generateSlots(opts: SlotOptions): string[] {
       const busyStart = addMinutes(b.start, -bufferBefore);
       const busyEnd = addMinutes(b.end, bufferAfter);
       
-      if (s >= busyStart && s <= busyEnd) {
+      if (s >= busyStart && s < busyEnd) {
         isBlocked = true;
         break;
       }


### PR DESCRIPTION
## Summary
- fix buffer filtering logic so events can start immediately after a busy period when no buffer_after is set

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9910d1ac8320acba94272497ed79