### PR TITLE
Fix buffer check in slot generator

### DIFF
--- a/backend/src/event-types/slot.utils.ts
+++ b/backend/src/event-types/slot.utils.ts
@@ -66,7 +66,7 @@ export function generateSlots(opts: SlotOptions): string[] {
       const busyStart = addMinutes(b.start, -bufferBefore);
       const busyEnd = addMinutes(b.end, bufferAfter);
       
-      if (s >= busyStart && s <= busyEnd) {
+      if (s >= busyStart && s < busyEnd) {
         isBlocked = true;
         break;
       }

--- a/booking/index.html
+++ b/booking/index.html
@@ -867,7 +867,7 @@
 
                 const dayNames = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
                 const dayAvail = JSON.parse(localStorage.getItem('calendarify-day-availability') || '{}');
-                const isDayOff = dayAvail[dayNames[selectedDate.getUTCDay()]] === true;
+                const isDayOff = dayAvail[dayNames[selectedDate.getUTCDay()]] === false;
 
                 if (selectedDate < new Date(new Date().setHours(0,0,0,0)) || isDayOff) {
                     container.innerHTML = '<p class="text-center text-gray-500">No availability</p>';
@@ -956,7 +956,7 @@
                     const isPast = currentDay < todayUTC;
                     const dayOfWeek = currentDay.getUTCDay();
                     const dayName = dayNamesFull[dayOfWeek];
-                    const isDayOff = dayAvail[dayName] === true;
+                    const isDayOff = dayAvail[dayName] === false;
                     
                     // Start with basic availability check - only check past dates, not weekends
                     let isUnavailable = isPast || isDayOff;


### PR DESCRIPTION
## Summary
- fix buffer filtering logic so events can start immediately after a busy period when no buffer_after is set
- fix day-off checks in booking page calendar

## Testing
- `npm test` *(fails: ENOENT '.env' & unable to reach Apple Calendar)*

------
https://chatgpt.com/codex/tasks/task_e_688b9910d1ac8320acba94272497ed79